### PR TITLE
Ensure operator can work in absence of cluster DNS

### DIFF
--- a/manifests/02-deployment.yaml
+++ b/manifests/02-deployment.yaml
@@ -13,17 +13,31 @@ spec:
       labels:
         name: cluster-dns-operator
     spec:
-      containers:
-        - name: cluster-dns-operator
-          image: openshift/origin-cluster-dns-operator:latest
-          command:
-          - cluster-dns-operator
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: WATCH_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: OPERATOR_NAME
-              value: "cluster-dns-operator"
       serviceAccountName: cluster-dns-operator
+      # The operator can't rely on cluster DNS to contact the apiserver, so use
+      # host networking and talk to the apiserver over loopback.
+      hostNetwork: true
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"
+      restartPolicy: Always
+      containers:
+      - name: cluster-dns-operator
+        image: openshift/origin-cluster-dns-operator:latest
+        command:
+        - cluster-dns-operator
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
+        - name: KUBERNETES_SERVICE_PORT
+          value: 8443
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OPERATOR_NAME
+          value: "cluster-dns-operator"


### PR DESCRIPTION
Eliminate the dependency on cluster DNS for the operator itself by using host
networking and talking to the apiserver over loopback. Ensure the operator is
only scheduled to masters.