### PR TITLE
Use cluster dns ip address from install config if "available"

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -20,6 +20,12 @@
   revision = "de5bf2ad457846296e2031421a34e2568e304e35"
 
 [[projects]]
+  name = "github.com/apparentlymart/go-cidr"
+  packages = ["cidr"]
+  revision = "b1115bf8e14a60131a196f908223e4506b0ddc35"
+  version = "v1.0.0"
+
+[[projects]]
   branch = "master"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
@@ -583,6 +589,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e57f9be0697155b269b4c6ee5e96e7b5dc227c2946c74d371e8423a713fce276"
+  inputs-digest = "29ec95049e056eeef0a8c6cd07515998a3095eee3a540633598faad0b2e02600"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,3 +1,5 @@
 apiVersion: dns.openshift.io/v1alpha1
 kind: ClusterDNS
 projectName: cluster-dns-operator
+metadata:
+  name: "default"

--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -6,8 +6,12 @@ import (
 
 	dnsv1alpha1 "github.com/openshift/cluster-dns-operator/pkg/apis/dns/v1alpha1"
 	"github.com/openshift/cluster-dns-operator/pkg/manifests"
+	"github.com/openshift/cluster-dns-operator/pkg/util"
 
+	"github.com/operator-framework/operator-sdk/pkg/k8sclient"
 	"github.com/operator-framework/operator-sdk/pkg/sdk"
+
+	"github.com/sirupsen/logrus"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -61,6 +65,16 @@ func (h *Handler) deleteDNS(dns *dnsv1alpha1.ClusterDNS) error {
 }
 
 func (h *Handler) syncDNSUpdate(dns *dnsv1alpha1.ClusterDNS) error {
+	if dns.Spec.ClusterIP == nil {
+		// Check for default cluster ip.
+		ipaddr, err := util.ClusterDNSIP(k8sclient.GetKubeClient())
+		if err != nil {
+			logrus.Errorf("Getting cluster dns ip: %v", err)
+		} else {
+			logrus.Infof("Using default cluster dns ip address %s", ipaddr)
+			dns.Spec.ClusterIP = &ipaddr
+		}
+	}
 	ns, err := h.manifestFactory.DNSNamespace()
 	if err != nil {
 		return fmt.Errorf("couldn't build dns namespace: %v", err)

--- a/pkg/util/config.go
+++ b/pkg/util/config.go
@@ -1,0 +1,82 @@
+package util
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/apparentlymart/go-cidr/cidr"
+	"github.com/ghodss/yaml"
+
+	kapicore "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// INSTALLER_CONFIG_NAMESPACE is the namespace containing the installer config.
+	INSTALLER_CONFIG_NAMESPACE = "kube-system"
+
+	// CLUSTER_CONFIG_RESOURCE is the resource containing the installer config.
+	CLUSTER_CONFIG_RESOURCE = "cluster-config-v1"
+)
+
+// installerClusterDNSIP
+func installerClusterDNSIP(cm *kapicore.ConfigMap) (string, error) {
+	if cm == nil {
+		return "", fmt.Errorf("invalid installer config")
+	}
+
+	ic, ok := cm.Data["install-config"]
+	if !ok {
+		return "", fmt.Errorf("missing installer config")
+	}
+
+	installConfigMap := make(map[string]interface{})
+	if err := yaml.Unmarshal([]byte(ic), &installConfigMap); err != nil {
+		return "", fmt.Errorf("unmarshall error: %v", err)
+	}
+
+	networking, ok := installConfigMap["networking"]
+	if !ok {
+		return "", fmt.Errorf("missing installer networking config")
+	}
+
+	networkingConfig, ok := networking.(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("invalid installer networking config")
+	}
+
+	serviceCIDR, ok := networkingConfig["serviceCIDR"]
+	if !ok {
+		return "", fmt.Errorf("missing networking service CIDR")
+	}
+
+	s, ok := serviceCIDR.(string)
+	if !ok {
+		return "", fmt.Errorf("invalid networking service CIDR")
+	}
+
+	_, ipnet, err := net.ParseCIDR(s)
+	if err != nil {
+		return "", fmt.Errorf("invalid networking service CIDR info")
+	}
+
+	ip, err := cidr.Host(ipnet, 10)
+	if err != nil {
+		return "", err
+	}
+
+	return ip.String(), nil
+}
+
+// ClusterDNSIP returns the cluster dns ip from the installer config.
+func ClusterDNSIP(client kubernetes.Interface) (string, error) {
+	resourceClient := client.CoreV1().ConfigMaps(INSTALLER_CONFIG_NAMESPACE)
+
+	obj, err := resourceClient.Get(CLUSTER_CONFIG_RESOURCE, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("getting %s resource: %v", CLUSTER_CONFIG_RESOURCE, err)
+	}
+
+	return installerClusterDNSIP(obj)
+}

--- a/vendor/github.com/apparentlymart/go-cidr/LICENSE
+++ b/vendor/github.com/apparentlymart/go-cidr/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2015 Martin Atkins
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/apparentlymart/go-cidr/cidr/cidr.go
+++ b/vendor/github.com/apparentlymart/go-cidr/cidr/cidr.go
@@ -1,0 +1,210 @@
+// Package cidr is a collection of assorted utilities for computing
+// network and host addresses within network ranges.
+//
+// It expects a CIDR-type address structure where addresses are divided into
+// some number of prefix bits representing the network and then the remaining
+// suffix bits represent the host.
+//
+// For example, it can help to calculate addresses for sub-networks of a
+// parent network, or to calculate host addresses within a particular prefix.
+//
+// At present this package is prioritizing simplicity of implementation and
+// de-prioritizing speed and memory usage. Thus caution is advised before
+// using this package in performance-critical applications or hot codepaths.
+// Patches to improve the speed and memory usage may be accepted as long as
+// they do not result in a significant increase in code complexity.
+package cidr
+
+import (
+	"fmt"
+	"math/big"
+	"net"
+)
+
+// Subnet takes a parent CIDR range and creates a subnet within it
+// with the given number of additional prefix bits and the given
+// network number.
+//
+// For example, 10.3.0.0/16, extended by 8 bits, with a network number
+// of 5, becomes 10.3.5.0/24 .
+func Subnet(base *net.IPNet, newBits int, num int) (*net.IPNet, error) {
+	ip := base.IP
+	mask := base.Mask
+
+	parentLen, addrLen := mask.Size()
+	newPrefixLen := parentLen + newBits
+
+	if newPrefixLen > addrLen {
+		return nil, fmt.Errorf("insufficient address space to extend prefix of %d by %d", parentLen, newBits)
+	}
+
+	maxNetNum := uint64(1<<uint64(newBits)) - 1
+	if uint64(num) > maxNetNum {
+		return nil, fmt.Errorf("prefix extension of %d does not accommodate a subnet numbered %d", newBits, num)
+	}
+
+	return &net.IPNet{
+		IP:   insertNumIntoIP(ip, num, newPrefixLen),
+		Mask: net.CIDRMask(newPrefixLen, addrLen),
+	}, nil
+}
+
+// Host takes a parent CIDR range and turns it into a host IP address with
+// the given host number.
+//
+// For example, 10.3.0.0/16 with a host number of 2 gives 10.3.0.2.
+func Host(base *net.IPNet, num int) (net.IP, error) {
+	ip := base.IP
+	mask := base.Mask
+
+	parentLen, addrLen := mask.Size()
+	hostLen := addrLen - parentLen
+
+	maxHostNum := uint64(1<<uint64(hostLen)) - 1
+
+	numUint64 := uint64(num)
+	if num < 0 {
+		numUint64 = uint64(-num) - 1
+		num = int(maxHostNum - numUint64)
+	}
+
+	if numUint64 > maxHostNum {
+		return nil, fmt.Errorf("prefix of %d does not accommodate a host numbered %d", parentLen, num)
+	}
+	var bitlength int
+	if ip.To4() != nil {
+		bitlength = 32
+	} else {
+		bitlength = 128
+	}
+	return insertNumIntoIP(ip, num, bitlength), nil
+}
+
+// AddressRange returns the first and last addresses in the given CIDR range.
+func AddressRange(network *net.IPNet) (net.IP, net.IP) {
+	// the first IP is easy
+	firstIP := network.IP
+
+	// the last IP is the network address OR NOT the mask address
+	prefixLen, bits := network.Mask.Size()
+	if prefixLen == bits {
+		// Easy!
+		// But make sure that our two slices are distinct, since they
+		// would be in all other cases.
+		lastIP := make([]byte, len(firstIP))
+		copy(lastIP, firstIP)
+		return firstIP, lastIP
+	}
+
+	firstIPInt, bits := ipToInt(firstIP)
+	hostLen := uint(bits) - uint(prefixLen)
+	lastIPInt := big.NewInt(1)
+	lastIPInt.Lsh(lastIPInt, hostLen)
+	lastIPInt.Sub(lastIPInt, big.NewInt(1))
+	lastIPInt.Or(lastIPInt, firstIPInt)
+
+	return firstIP, intToIP(lastIPInt, bits)
+}
+
+// AddressCount returns the number of distinct host addresses within the given
+// CIDR range.
+//
+// Since the result is a uint64, this function returns meaningful information
+// only for IPv4 ranges and IPv6 ranges with a prefix size of at least 65.
+func AddressCount(network *net.IPNet) uint64 {
+	prefixLen, bits := network.Mask.Size()
+	return 1 << (uint64(bits) - uint64(prefixLen))
+}
+
+//VerifyNoOverlap takes a list subnets and supernet (CIDRBlock) and verifies
+//none of the subnets overlap and all subnets are in the supernet
+//it returns an error if any of those conditions are not satisfied
+func VerifyNoOverlap(subnets []*net.IPNet, CIDRBlock *net.IPNet) error {
+	firstLastIP := make([][]net.IP, len(subnets))
+	for i, s := range subnets {
+		first, last := AddressRange(s)
+		firstLastIP[i] = []net.IP{first, last}
+	}
+	for i, s := range subnets {
+		if !CIDRBlock.Contains(firstLastIP[i][0]) || !CIDRBlock.Contains(firstLastIP[i][1]) {
+			return fmt.Errorf("%s does not fully contain %s", CIDRBlock.String(), s.String())
+		}
+		for j := i + 1; j < len(subnets); j++ {
+			first := firstLastIP[j][0]
+			last := firstLastIP[j][1]
+			if s.Contains(first) || s.Contains(last) {
+				return fmt.Errorf("%s overlaps with %s", subnets[j].String(), s.String())
+			}
+		}
+	}
+	return nil
+}
+
+// PreviousSubnet returns the subnet of the desired mask in the IP space
+// just lower than the start of IPNet provided. If the IP space rolls over
+// then the second return value is true
+func PreviousSubnet(network *net.IPNet, prefixLen int) (*net.IPNet, bool) {
+	startIP := checkIPv4(network.IP)
+	previousIP := make(net.IP, len(startIP))
+	copy(previousIP, startIP)
+	cMask := net.CIDRMask(prefixLen, 8*len(previousIP))
+	previousIP = Dec(previousIP)
+	previous := &net.IPNet{IP: previousIP.Mask(cMask), Mask: cMask}
+	if startIP.Equal(net.IPv4zero) || startIP.Equal(net.IPv6zero) {
+		return previous, true
+	}
+	return previous, false
+}
+
+// NextSubnet returns the next available subnet of the desired mask size
+// starting for the maximum IP of the offset subnet
+// If the IP exceeds the maxium IP then the second return value is true
+func NextSubnet(network *net.IPNet, prefixLen int) (*net.IPNet, bool) {
+	_, currentLast := AddressRange(network)
+	mask := net.CIDRMask(prefixLen, 8*len(currentLast))
+	currentSubnet := &net.IPNet{IP: currentLast.Mask(mask), Mask: mask}
+	_, last := AddressRange(currentSubnet)
+	last = Inc(last)
+	next := &net.IPNet{IP: last.Mask(mask), Mask: mask}
+	if last.Equal(net.IPv4zero) || last.Equal(net.IPv6zero) {
+		return next, true
+	}
+	return next, false
+}
+
+//Inc increases the IP by one this returns a new []byte for the IP
+func Inc(IP net.IP) net.IP {
+	IP = checkIPv4(IP)
+	incIP := make([]byte, len(IP))
+	copy(incIP, IP)
+	for j := len(incIP) - 1; j >= 0; j-- {
+		incIP[j]++
+		if incIP[j] > 0 {
+			break
+		}
+	}
+	return incIP
+}
+
+//Dec decreases the IP by one this returns a new []byte for the IP
+func Dec(IP net.IP) net.IP {
+	IP = checkIPv4(IP)
+	decIP := make([]byte, len(IP))
+	copy(decIP, IP)
+	decIP = checkIPv4(decIP)
+	for j := len(decIP) - 1; j >= 0; j-- {
+		decIP[j]--
+		if decIP[j] < 255 {
+			break
+		}
+	}
+	return decIP
+}
+
+func checkIPv4(ip net.IP) net.IP {
+	// Go for some reason allocs IPv6len for IPv4 so we have to correct it
+	if v4 := ip.To4(); v4 != nil {
+		return v4
+	}
+	return ip
+}

--- a/vendor/github.com/apparentlymart/go-cidr/cidr/wrangling.go
+++ b/vendor/github.com/apparentlymart/go-cidr/cidr/wrangling.go
@@ -1,0 +1,38 @@
+package cidr
+
+import (
+	"fmt"
+	"math/big"
+	"net"
+)
+
+func ipToInt(ip net.IP) (*big.Int, int) {
+	val := &big.Int{}
+	val.SetBytes([]byte(ip))
+	if len(ip) == net.IPv4len {
+		return val, 32
+	} else if len(ip) == net.IPv6len {
+		return val, 128
+	} else {
+		panic(fmt.Errorf("Unsupported address length %d", len(ip)))
+	}
+}
+
+func intToIP(ipInt *big.Int, bits int) net.IP {
+	ipBytes := ipInt.Bytes()
+	ret := make([]byte, bits/8)
+	// Pack our IP bytes into the end of the return array,
+	// since big.Int.Bytes() removes front zero padding.
+	for i := 1; i <= len(ipBytes); i++ {
+		ret[len(ret)-i] = ipBytes[len(ipBytes)-i]
+	}
+	return net.IP(ret)
+}
+
+func insertNumIntoIP(ip net.IP, num int, prefixLen int) net.IP {
+	ipInt, totalBits := ipToInt(ip)
+	bigNum := big.NewInt(int64(num))
+	bigNum.Lsh(bigNum, uint(totalBits-prefixLen))
+	ipInt.Or(ipInt, bigNum)
+	return intToIP(ipInt, totalBits)
+}


### PR DESCRIPTION
Configure the operator to use the same DNS IP used by the kubelet

jira ticket: https://jira.coreos.com/browse/NE-86

/cc @openshift/sig-network-edge    
PTAL  Thx

*Edited* Removed old test info