### PR TITLE
Allow role to get objects for getting installer config map.

### DIFF
--- a/manifests/00-cluster-role.yaml
+++ b/manifests/00-cluster-role.yaml
@@ -32,5 +32,6 @@ rules:
   - clusterrolebindings
   verbs:
   - create
+  - get
   - list
   - watch


### PR DESCRIPTION
/cc @openshift/sig-network-edge 

@pravisankar  PTAL thx