### PR TITLE
Makefile changes to add targets for building local image and gofmt verification

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -157,7 +157,7 @@ func (f *Factory) DNSDaemonSet(dns *dnsv1alpha1.ClusterDNS) (*appsv1.DaemonSet, 
 	ds.Spec.Selector.MatchLabels["dns"] = ds.Name
 
 	coreFileVolumeFound := false
-	for i, _ := range ds.Spec.Template.Spec.Volumes {
+	for i := range ds.Spec.Template.Spec.Volumes {
 		if ds.Spec.Template.Spec.Volumes[i].Name == "config-volume" {
 			ds.Spec.Template.Spec.Volumes[i].ConfigMap.Name = ds.Name
 			coreFileVolumeFound = true


### PR DESCRIPTION
Add makefile targets to build local images and verifying go code with gofmt.
Plus fix the gofmt issue that this found. 
@pravisankar  PTAL Thx

/cc @openshift/sig-network-edge 
