### PR TITLE
Add daemonset permissions to operator

### DIFF
--- a/manifests/0000_08_cluster-dns-operator_00-cluster-role.yaml
+++ b/manifests/0000_08_cluster-dns-operator_00-cluster-role.yaml
@@ -17,7 +17,7 @@ rules:
   resources:
   - daemonsets
   verbs:
-  - create
+  - "*"
 - apiGroups:
   - ""
   - rbac.authorization.k8s.io


### PR DESCRIPTION
Fixes the error:

```
time="2018-10-09T19:48:55Z" level=error msg="error syncing key (openshift-cluster-dns-operator/default): failed to fetch daemonset dns-default, daemonsets.apps \"dns-default\" is forbidden: User \"system:serviceaccount:openshift-cluster-dns-operator:cluster-dns-operator\" cannot get daemonsets.apps in the namespace \"openshift-cluster-dns\": no RBAC policy matched"
```