### PR TITLE
manifests: allow dns operator to schedule on any node

### DIFF
--- a/manifests/0000_08_cluster-dns-operator_02-deployment.yaml
+++ b/manifests/0000_08_cluster-dns-operator_02-deployment.yaml
@@ -30,3 +30,5 @@ spec:
             - name: OPERATOR_NAME
               value: "cluster-dns-operator"
       serviceAccountName: cluster-dns-operator
+      tolerations:
+      - operator: Exists # dns operator should be schedulable always.


### PR DESCRIPTION
https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/#concepts has docs
that define a toleration that tolerates evrything
```
An empty key with operator Exists matches all keys, values and effects which means this will tolerate everything.
```

/cc @ramr