### PR TITLE
release-local.sh fixes

### DIFF
--- a/hack/release-local.sh
+++ b/hack/release-local.sh
@@ -23,7 +23,7 @@ if [[ "${TEMP_COMMIT}" == "true" ]]; then
   git reset --soft HEAD~1
 fi
 
-cp -R manifests/ $MANIFESTS
+cp -R manifests/* $MANIFESTS
 cat manifests/0000_08_cluster-dns-operator_02-deployment.yaml | sed "s~openshift/origin-cluster-dns-operator:latest~$REPO:$REV~" > "$MANIFESTS/0000_08_cluster-dns-operator_02-deployment.yaml"
 
 echo "Pushed $REPO:$REV"

--- a/hack/release-local.sh
+++ b/hack/release-local.sh
@@ -16,8 +16,13 @@ if [[ "${TEMP_COMMIT}" == "true" ]]; then
 fi
 
 REV=$(git rev-parse --short HEAD)
-docker build -t $REPO:$REV .
-docker push $REPO:$REV
+if [[ -z "${DOCKER+1}" ]] && command -v buildah >& /dev/null; then
+  buildah bud -t $REPO:$REV .
+  buildah push $REPO:$REV docker://$REPO:$REV
+else
+  docker build -t $REPO:$REV .
+  docker push $REPO:$REV
+fi
 
 if [[ "${TEMP_COMMIT}" == "true" ]]; then
   git reset --soft HEAD~1


### PR DESCRIPTION
Cherry-pick https://github.com/openshift/cluster-ingress-operator/pull/56 and https://github.com/openshift/cluster-ingress-operator/pull/57.

#### `release-local.sh`: Fix `cp` command for manifests

Fix the `cp` command in `release-local.sh` to copy the manifest files directly into the temporary directory rather than copying the `manifests/` directory as a subdirectory of the temporary directory.  This change causes the subsequent sed command to overwrite the `0000_08_cluster-dns-operator_02-deployment.yaml` file.

Before this commit, on some operating systems, the cp command in `release-local.sh` was copying the `manifests/` directory under the temporary directory, and the subsequent sed command was creating a second `0000_08_cluster-dns-operator_02-deployment.yaml` file in the temporary directory, as shown below:

    /tmp/tmp.tXJWHA970j
    ├── 0000_08_cluster-dns-operator_02-deployment.yaml
    └── manifests
        ├── 0000_08_cluster-dns-operator_00-cluster-role.yaml
        ├── 0000_08_cluster-dns-operator_00-custom-resource-definition.yaml
        ├── 0000_08_cluster-dns-operator_00-namespace.yaml
        ├── 0000_08_cluster-dns-operator_01-cluster-role-binding.yaml
        ├── 0000_08_cluster-dns-operator_01-role-binding.yaml
        ├── 0000_08_cluster-dns-operator_01-role.yaml
        ├── 0000_08_cluster-dns-operator_01-service-account.yaml
        ├── 0000_08_cluster-dns-operator_02-deployment.yaml
        └── image-references

Having this file hierarchy was causing the following error:

    $ oc apply -f /tmp/tmp.tXJWHA970j
    Error from server (NotFound): error when creating "/tmp/tmp.tXJWHA970j/0000_08_cluster-dns-operator_02-deployment.yaml": namespaces "openshift-cluster-dns-operator" not found

After this change, the file hierarchy looks as follows:

    /tmp/tmp.WFJn4ZZ0Hu
    ├── 0000_08_cluster-dns-operator_00-cluster-role.yaml
    ├── 0000_08_cluster-dns-operator_00-custom-resource-definition.yaml
    ├── 0000_08_cluster-dns-operator_00-namespace.yaml
    ├── 0000_08_cluster-dns-operator_01-cluster-role-binding.yaml
    ├── 0000_08_cluster-dns-operator_01-role-binding.yaml
    ├── 0000_08_cluster-dns-operator_01-role.yaml
    ├── 0000_08_cluster-dns-operator_01-service-account.yaml
    ├── 0000_08_cluster-dns-operator_02-deployment.yaml
    └── image-references

...and the `oc apply` command succeeds.


#### `release-local.sh`: Use Buildah if available.

Check in `release-local.sh` whether Buildah is available, and use it if it is.  Setting the `DOCKER` environment variable forces the use of Docker.
