### PR TITLE
 Restrict operator to linux hosts

### DIFF
--- a/manifests/0000_08_cluster-dns-operator_02-deployment.yaml
+++ b/manifests/0000_08_cluster-dns-operator_02-deployment.yaml
@@ -15,6 +15,7 @@ spec:
     spec:
       dnsPolicy: Default
       nodeSelector:
+        beta.kubernetes.io/os: linux
         node-role.kubernetes.io/master: ''
       restartPolicy: Always
       priorityClassName: system-cluster-critical

--- a/pkg/stub/status.go
+++ b/pkg/stub/status.go
@@ -52,10 +52,9 @@ func (h *Handler) syncOperatorStatus() {
 	oldConditions := co.Status.Conditions
 	co.Status.Conditions = computeStatusConditions(oldConditions, ns,
 		dnses, daemonsets)
+	co.Status.Version = operatorversion.Version
 
 	if isNotFound {
-		co.Status.Version = operatorversion.Version
-
 		if err := sdk.Create(co); err != nil {
 			logrus.Errorf("syncOperatorStatus: failed to create ClusterOperator %s: %v",
 				co.Name, err)


### PR DESCRIPTION
- Also set dns cluster operator status version during create and update.