### PR TITLE
docs/readme: Add Bugzilla issue reporting link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,7 @@ Cluster DNS Operator manages CoreDNS as a Kubernetes DaemonSet exposed as a Serv
 ## How to help
 
 See [HACKING.md](HACKING.md) for development topics.
+
+## Reporting issues
+
+Bugs are tracked in [Bugzilla](https://bugzilla.redhat.com/enter_bug.cgi?product=OpenShift%20Container%20Platform&version=4.0.0&component=Routing).


### PR DESCRIPTION
Bugs are tracked in Bugzilla. GitHub issues are disabled for the repository, so make a note in the README to redirect users to Bugzilla.