### PR TITLE
Set semantic versions in clusteroperator status

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -42,6 +42,14 @@
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
+  digest = "1:0ef770954bca104ee99b3b6b7f9b240605ac03517d9f98cbc1893daa03f3c038"
+  name = "github.com/coreos/go-semver"
+  packages = ["semver"]
+  pruneopts = "NUT"
+  revision = "8ab6407b697782a06568d4b7f1db25550ec2e4c6"
+  version = "v0.2.0"
+
+[[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
@@ -722,7 +730,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/apparentlymart/go-cidr/cidr",
-    "github.com/ghodss/yaml",
+    "github.com/coreos/go-semver/semver",
     "github.com/kevinburke/go-bindata",
     "github.com/openshift/api/config/v1",
     "github.com/operator-framework/operator-sdk/pkg/k8sclient",
@@ -741,7 +749,6 @@
     "k8s.io/apimachinery/pkg/util/errors",
     "k8s.io/apimachinery/pkg/util/wait",
     "k8s.io/apimachinery/pkg/util/yaml",
-    "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/plugin/pkg/client/auth/gcp",
     "k8s.io/code-generator/cmd/client-gen",
     "k8s.io/code-generator/cmd/conversion-gen",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -28,6 +28,10 @@ required = [
   unused-packages = false
 
 [[constraint]]
+  name = "github.com/coreos/go-semver"
+  version = "=v0.2.0"
+
+[[constraint]]
   name = "github.com/operator-framework/operator-sdk"
   version = "v0.0.6"
 

--- a/cmd/cluster-dns-operator/main.go
+++ b/cmd/cluster-dns-operator/main.go
@@ -47,10 +47,15 @@ func main() {
 	if len(cliImage) == 0 {
 		logrus.Fatalf("OPENSHIFT_CLI_IMAGE environment variable is required")
 	}
+	operatorImageVersion := os.Getenv("OPERATOR_IMAGE_VERSION")
+	if len(operatorImageVersion) == 0 {
+		logrus.Fatalf("OPERATOR_IMAGE_VERSION environment variable is required")
+	}
 
 	operatorConfig := operator.Config{
-		CoreDNSImage:      coreDNSImage,
-		OpenshiftCLIImage: cliImage,
+		CoreDNSImage:         coreDNSImage,
+		OpenshiftCLIImage:    cliImage,
+		OperatorImageVersion: operatorImageVersion,
 	}
 
 	handler := &stub.Handler{

--- a/manifests/0000_08_cluster-dns-operator_01-version-mapping.yaml
+++ b/manifests/0000_08_cluster-dns-operator_01-version-mapping.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: openshift-dns-operator
+  name: version-mapping
+data:
+  "0.0.0_version_coredns": "openshift/origin-coredns:v4.0"
+  "0.0.0_version_origin-cli": "openshift/origin-cli:v4.0"
+  "0.0.0_version_cluster-dns-operator": "openshift/origin-cluster-dns-operator:latest"

--- a/manifests/0000_08_cluster-dns-operator_02-deployment.yaml
+++ b/manifests/0000_08_cluster-dns-operator_02-deployment.yaml
@@ -31,6 +31,8 @@ spec:
               value: openshift/origin-coredns:v4.0
             - name: OPENSHIFT_CLI_IMAGE
               value: openshift/origin-cli:v4.0
+            - name: OPERATOR_IMAGE_VERSION
+              value: 0.0.0_version_cluster-dns-operator
           resources:
             requests:
               cpu: 10m

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -7,4 +7,6 @@ type Config struct {
 	CoreDNSImage string
 	// OpenshiftCLIImage is the openshift client image to manage.
 	OpenshiftCLIImage string
+	// OperatorImageVersion is the operator image version.
+	OperatorImageVersion string
 }

--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -36,15 +36,15 @@ type Handler struct {
 }
 
 func (h *Handler) Handle(ctx context.Context, event sdk.Event) error {
-	defer h.syncOperatorStatus()
-
 	// TODO: This should be adding an item to a rate limited work queue, but for
 	// now correctness is more important than performance.
 	switch o := event.Object.(type) {
 	case *dnsv1alpha1.ClusterDNS:
 		logrus.Infof("reconciling for update to clusterdns %q", o.Name)
 	}
-	return h.reconcile()
+	reconcileErr := h.reconcile()
+	syncErr := h.syncOperatorStatus()
+	return utilerrors.NewAggregate([]error{reconcileErr, syncErr})
 }
 
 // EnsureDefaultClusterDNS ensures that the default ClusterDNS exists.

--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -53,7 +53,7 @@ func (h *Handler) EnsureDefaultClusterDNS() error {
 	networkConfig := &configv1.Network{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Network",
-			APIVersion: "config.openshift.io/v1",
+			APIVersion: configv1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "cluster",
@@ -89,7 +89,7 @@ func (h *Handler) reconcile() error {
 	dnses := &dnsv1alpha1.ClusterDNSList{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ClusterDNS",
-			APIVersion: "dns.openshift.io/v1alpha1",
+			APIVersion: dnsv1alpha1.SchemeGroupVersion.String(),
 		},
 	}
 	err = sdk.List(corev1.NamespaceAll, dnses, sdk.WithListOptions(&metav1.ListOptions{}))

--- a/pkg/stub/status.go
+++ b/pkg/stub/status.go
@@ -28,7 +28,7 @@ func (h *Handler) syncOperatorStatus() {
 	co := &configv1.ClusterOperator{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ClusterOperator",
-			APIVersion: "config.openshift.io/v1",
+			APIVersion: configv1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "dns",
@@ -129,7 +129,7 @@ func (h *Handler) getOperatorState() (*corev1.Namespace, []dnsv1alpha1.ClusterDN
 	dnsList := &dnsv1alpha1.ClusterDNSList{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ClusterDNS",
-			APIVersion: "dns.openshift.io/v1alpha1",
+			APIVersion: dnsv1alpha1.SchemeGroupVersion.String(),
 		},
 	}
 	if err := sdk.List(corev1.NamespaceAll, dnsList, sdk.WithListOptions(&metav1.ListOptions{})); err != nil {
@@ -139,7 +139,7 @@ func (h *Handler) getOperatorState() (*corev1.Namespace, []dnsv1alpha1.ClusterDN
 	daemonsetList := &appsv1.DaemonSetList{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "DaemonSet",
-			APIVersion: "apps/v1",
+			APIVersion: appsv1.SchemeGroupVersion.String(),
 		},
 	}
 	if err := sdk.List(ns.Name, daemonsetList, sdk.WithListOptions(&metav1.ListOptions{})); err != nil {

--- a/pkg/stub/status.go
+++ b/pkg/stub/status.go
@@ -85,6 +85,10 @@ func (h *Handler) syncOperatorStatus() {
 		} else {
 			logrus.Infof("syncOperatorStatus: created ClusterOperator %s (UID %v)",
 				co.Name, co.UID)
+			if err := sdk.Get(co); err != nil {
+				logrus.Errorf("syncOperatorStatus: error getting ClusterOperator %s: %v", co.Name, err)
+				return
+			}
 		}
 	}
 

--- a/pkg/stub/status_test.go
+++ b/pkg/stub/status_test.go
@@ -47,12 +47,12 @@ func TestComputeStatusConditions(t *testing.T) {
 			namespace = &corev1.Namespace{}
 		}
 		for i := 0; i < tc.inputs.numWanted; i++ {
-			clusterdnses = append(clusterdnses,
-				dnsv1alpha1.ClusterDNS{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: fmt.Sprintf("%d", i+1),
-					},
-				})
+			clusterdns := dnsv1alpha1.ClusterDNS{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: fmt.Sprintf("%d", i+1),
+				},
+			}
+			clusterdnses = append(clusterdnses, clusterdns)
 		}
 		numDaemonsets := tc.inputs.numAvailable + tc.inputs.numUnavailable
 		for i := 0; i < numDaemonsets; i++ {
@@ -124,8 +124,7 @@ func TestComputeStatusConditions(t *testing.T) {
 			}
 		}
 		if !gotExpected {
-			t.Fatalf("%q: expected %#v, got %#v", tc.description,
-				expected, new)
+			t.Fatalf("%q: expected %#v, got %#v", tc.description, expected, new)
 		}
 	}
 }

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -19,7 +19,7 @@ func TestOperatorAvailable(t *testing.T) {
 	co := &configv1.ClusterOperator{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ClusterOperator",
-			APIVersion: "config.openshift.io/v1",
+			APIVersion: configv1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "dns",
@@ -48,7 +48,7 @@ func TestDefaultClusterDNSExists(t *testing.T) {
 	dns := &dnsv1alpha1.ClusterDNS{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ClusterDNS",
-			APIVersion: "dns.openshift.io/v1alpha1",
+			APIVersion: dnsv1alpha1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "default",

--- a/vendor/github.com/coreos/go-semver/LICENSE
+++ b/vendor/github.com/coreos/go-semver/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/coreos/go-semver/semver/semver.go
+++ b/vendor/github.com/coreos/go-semver/semver/semver.go
@@ -1,0 +1,268 @@
+// Copyright 2013-2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Semantic Versions http://semver.org
+package semver
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type Version struct {
+	Major      int64
+	Minor      int64
+	Patch      int64
+	PreRelease PreRelease
+	Metadata   string
+}
+
+type PreRelease string
+
+func splitOff(input *string, delim string) (val string) {
+	parts := strings.SplitN(*input, delim, 2)
+
+	if len(parts) == 2 {
+		*input = parts[0]
+		val = parts[1]
+	}
+
+	return val
+}
+
+func New(version string) *Version {
+	return Must(NewVersion(version))
+}
+
+func NewVersion(version string) (*Version, error) {
+	v := Version{}
+
+	if err := v.Set(version); err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}
+
+// Must is a helper for wrapping NewVersion and will panic if err is not nil.
+func Must(v *Version, err error) *Version {
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+// Set parses and updates v from the given version string. Implements flag.Value
+func (v *Version) Set(version string) error {
+	metadata := splitOff(&version, "+")
+	preRelease := PreRelease(splitOff(&version, "-"))
+	dotParts := strings.SplitN(version, ".", 3)
+
+	if len(dotParts) != 3 {
+		return fmt.Errorf("%s is not in dotted-tri format", version)
+	}
+
+	parsed := make([]int64, 3, 3)
+
+	for i, v := range dotParts[:3] {
+		val, err := strconv.ParseInt(v, 10, 64)
+		parsed[i] = val
+		if err != nil {
+			return err
+		}
+	}
+
+	v.Metadata = metadata
+	v.PreRelease = preRelease
+	v.Major = parsed[0]
+	v.Minor = parsed[1]
+	v.Patch = parsed[2]
+	return nil
+}
+
+func (v Version) String() string {
+	var buffer bytes.Buffer
+
+	fmt.Fprintf(&buffer, "%d.%d.%d", v.Major, v.Minor, v.Patch)
+
+	if v.PreRelease != "" {
+		fmt.Fprintf(&buffer, "-%s", v.PreRelease)
+	}
+
+	if v.Metadata != "" {
+		fmt.Fprintf(&buffer, "+%s", v.Metadata)
+	}
+
+	return buffer.String()
+}
+
+func (v *Version) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var data string
+	if err := unmarshal(&data); err != nil {
+		return err
+	}
+	return v.Set(data)
+}
+
+func (v Version) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + v.String() + `"`), nil
+}
+
+func (v *Version) UnmarshalJSON(data []byte) error {
+	l := len(data)
+	if l == 0 || string(data) == `""` {
+		return nil
+	}
+	if l < 2 || data[0] != '"' || data[l-1] != '"' {
+		return errors.New("invalid semver string")
+	}
+	return v.Set(string(data[1 : l-1]))
+}
+
+// Compare tests if v is less than, equal to, or greater than versionB,
+// returning -1, 0, or +1 respectively.
+func (v Version) Compare(versionB Version) int {
+	if cmp := recursiveCompare(v.Slice(), versionB.Slice()); cmp != 0 {
+		return cmp
+	}
+	return preReleaseCompare(v, versionB)
+}
+
+// Equal tests if v is equal to versionB.
+func (v Version) Equal(versionB Version) bool {
+	return v.Compare(versionB) == 0
+}
+
+// LessThan tests if v is less than versionB.
+func (v Version) LessThan(versionB Version) bool {
+	return v.Compare(versionB) < 0
+}
+
+// Slice converts the comparable parts of the semver into a slice of integers.
+func (v Version) Slice() []int64 {
+	return []int64{v.Major, v.Minor, v.Patch}
+}
+
+func (p PreRelease) Slice() []string {
+	preRelease := string(p)
+	return strings.Split(preRelease, ".")
+}
+
+func preReleaseCompare(versionA Version, versionB Version) int {
+	a := versionA.PreRelease
+	b := versionB.PreRelease
+
+	/* Handle the case where if two versions are otherwise equal it is the
+	 * one without a PreRelease that is greater */
+	if len(a) == 0 && (len(b) > 0) {
+		return 1
+	} else if len(b) == 0 && (len(a) > 0) {
+		return -1
+	}
+
+	// If there is a prerelease, check and compare each part.
+	return recursivePreReleaseCompare(a.Slice(), b.Slice())
+}
+
+func recursiveCompare(versionA []int64, versionB []int64) int {
+	if len(versionA) == 0 {
+		return 0
+	}
+
+	a := versionA[0]
+	b := versionB[0]
+
+	if a > b {
+		return 1
+	} else if a < b {
+		return -1
+	}
+
+	return recursiveCompare(versionA[1:], versionB[1:])
+}
+
+func recursivePreReleaseCompare(versionA []string, versionB []string) int {
+	// A larger set of pre-release fields has a higher precedence than a smaller set,
+	// if all of the preceding identifiers are equal.
+	if len(versionA) == 0 {
+		if len(versionB) > 0 {
+			return -1
+		}
+		return 0
+	} else if len(versionB) == 0 {
+		// We're longer than versionB so return 1.
+		return 1
+	}
+
+	a := versionA[0]
+	b := versionB[0]
+
+	aInt := false
+	bInt := false
+
+	aI, err := strconv.Atoi(versionA[0])
+	if err == nil {
+		aInt = true
+	}
+
+	bI, err := strconv.Atoi(versionB[0])
+	if err == nil {
+		bInt = true
+	}
+
+	// Handle Integer Comparison
+	if aInt && bInt {
+		if aI > bI {
+			return 1
+		} else if aI < bI {
+			return -1
+		}
+	}
+
+	// Handle String Comparison
+	if a > b {
+		return 1
+	} else if a < b {
+		return -1
+	}
+
+	return recursivePreReleaseCompare(versionA[1:], versionB[1:])
+}
+
+// BumpMajor increments the Major field by 1 and resets all other fields to their default values
+func (v *Version) BumpMajor() {
+	v.Major += 1
+	v.Minor = 0
+	v.Patch = 0
+	v.PreRelease = PreRelease("")
+	v.Metadata = ""
+}
+
+// BumpMinor increments the Minor field by 1 and resets all other fields to their default values
+func (v *Version) BumpMinor() {
+	v.Minor += 1
+	v.Patch = 0
+	v.PreRelease = PreRelease("")
+	v.Metadata = ""
+}
+
+// BumpPatch increments the Patch field by 1 and resets all other fields to their default values
+func (v *Version) BumpPatch() {
+	v.Patch += 1
+	v.PreRelease = PreRelease("")
+	v.Metadata = ""
+}

--- a/vendor/github.com/coreos/go-semver/semver/sort.go
+++ b/vendor/github.com/coreos/go-semver/semver/sort.go
@@ -1,0 +1,38 @@
+// Copyright 2013-2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semver
+
+import (
+	"sort"
+)
+
+type Versions []*Version
+
+func (s Versions) Len() int {
+	return len(s)
+}
+
+func (s Versions) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s Versions) Less(i, j int) bool {
+	return s[i].LessThan(*s[j])
+}
+
+// Sort sorts the given slice of Version
+func Sort(versions []*Version) {
+	sort.Sort(Versions(versions))
+}

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,0 @@
-package version
-
-var (
-	Version = "0.0.1"
-)


### PR DESCRIPTION
## Add `coreos/go-semver` dependency

* `Gopkg.lock`:
* `Gopkg.toml`:
* `vendor/github.com/coreos/go-semver`: Import package in order to parse and compare semantic versions.

## Set semantic versions in clusteroperator status

This commit resolves [NE-147](https://jira.coreos.com/browse/NE-147).

* `cmd/cluster-dns-operator/main.go` (`main`): Read `OPERATOR_IMAGE_VERSION` and add use its value to set `OperatorImageVersion` in the operator config.
* `manifests/0000_08_cluster-dns-operator_01-version-mapping.yaml`: New file with the `version-mapping` configmap.
* `manifests/0000_08_cluster-dns-operator_02-deployment.yaml`: Add `OPERATOR_IMAGE_VERSION` environment variable.
* `pkg/operator/config.go` (`Config`): Add `OperatorImageVersion` field.
* `pkg/stub/status.go` (`syncOperatorStatus`): Use new functions `getVersionMap` and `computeStatusVersions` to set `status.versions`.
(`getVersionMap`): New function to get the `version-mapping` configmap.
(`computeStatusVersions`): New function to compute `status.versions` for the operator and its operands given the operator image, daemonsets, and version map, using `getSemVerForPullspec`.
(`getSemVerForPullspec`): New function to get the semantic version from the pullspec, using the version map.
* `pkg/stub/status_test.go` (`TestComputeStatusVersions`): New test.
* `version/version.go`: Deleted.

## Get new clusteroperator before updating status

The operator must get a newly created clusteroperator from the API before attempting to update its status, or else the attempted update will fail with the following error:

    metadata.resourceVersion: Invalid value: 0x0: must be specified for an update

* `pkg/stub/status.go` (`syncOperatorStatus`): Get the clusteroperator after creating it.

## Improve logging and formatting in status code

Change some log messages and code formatting to be more readable and stylistically consistent.

* `pkg/stub/status.go` (`syncOperatorStatus`, `getOperatorState`): Unwrap long lines, reformat some statements, delete blank lines before returns, improve some log messages, and use `%q` when printing the name of a resource.
(`computeStatusConditions`): Unwrap long lines.
* `pkg/stub/status_test.go` (`TestComputeStatusConditions`): Unwrap or reformat some long lines.


## Use `SchemeGroupVersion.String()` to get API versions

* `pkg/stub/handler.go` (`EnsureDefaultClusterDNS`, `reconcile`):
* `pkg/stub/status.go` (`syncOperatorStatus`, `getOperatorState`):
* `test/e2e/operator_test.go` (`TestOperatorAvailable`, `TestDefaultClusterDNSExists`): Replace string literals with `SchemeGroupVersion.String()` wherever possible.

## Clean up not-found logic in `syncOperatorStatus`

* `pkg/stub/status.go` (`syncOperatorStatus`): Clean up the logic that handles not-found errors when getting the clusteroperator.

## Re-trigger an event if status update fails

Return a non-nil error value from the event handler if `syncOperatorStatus` fails.  Failing to update the clusteroperator status may block cluster-version-operator from progressing, so it is important to retry the update immediately, rather than waiting for the next resync interval.

* `pkg/stub/handler.go` (`Handle`): Expect an error value from `syncOperatorStatus`.  Aggregate and return the error values from `reconcile` and `syncOperatorStatus`.
* `pkg/stub/status.go` (`syncOperatorStatus`): Return an error value.