### PR TITLE
status: report cluster operator version from payload

### DIFF
--- a/manifests/0000_08_cluster-dns-operator_02-deployment.yaml
+++ b/manifests/0000_08_cluster-dns-operator_02-deployment.yaml
@@ -27,6 +27,8 @@ spec:
           - cluster-dns-operator
           terminationGracePeriodSeconds: 2
           env:
+            - name: RELEASE_VERSION
+              value: "0.0.1-snapshot"
             - name: IMAGE
               value: openshift/origin-coredns:v4.0
             - name: OPENSHIFT_CLI_IMAGE

--- a/manifests/0000_08_cluster-dns-operator_03-cluster-operator.yaml
+++ b/manifests/0000_08_cluster-dns-operator_03-cluster-operator.yaml
@@ -3,3 +3,7 @@ kind: ClusterOperator
 metadata:
   name: dns
 spec: {}
+status:
+  versions:
+    - name: operator
+      version: "0.0.1-snapshot"


### PR DESCRIPTION
Every operator shall report a version with name=operator whose value is equal to the RELEASE_VERSION provided by the cluster version operator.

will be enforced via [openshift/origin#22156](https://github.com/openshift/origin/pull/22156)