### PR TITLE
Check RELEASE_VERSION env existence before starting the reconciliation.

### DIFF
--- a/cmd/cluster-dns-operator/main.go
+++ b/cmd/cluster-dns-operator/main.go
@@ -49,8 +49,9 @@ func main() {
 	}
 
 	operatorConfig := operator.Config{
-		CoreDNSImage:      coreDNSImage,
-		OpenshiftCLIImage: cliImage,
+		OperatorReleaseVersion: os.Getenv("RELEASE_VERSION"),
+		CoreDNSImage:           coreDNSImage,
+		OpenshiftCLIImage:      cliImage,
 	}
 
 	handler := &stub.Handler{

--- a/hack/uninstall.sh
+++ b/hack/uninstall.sh
@@ -9,7 +9,7 @@ oc patch clusterdnses/default --patch '{"metadata":{"finalizers": []}}' --type=m
 oc delete --force --grace-period 0 clusterdnses/default
 oc delete namespaces/openshift-dns-operator
 oc delete namespaces/openshift-dns
-oc delete clusteroperator openshift-dns-operator
+oc delete clusteroperator dns
 oc delete clusterroles/openshift-dns-operator
 oc delete clusterroles/openshift-dns
 oc delete clusterrolebindings/openshift-dns-operator

--- a/manifests/0000_08_cluster-dns-operator_03-cluster-operator.yaml
+++ b/manifests/0000_08_cluster-dns-operator_03-cluster-operator.yaml
@@ -4,6 +4,4 @@ metadata:
   name: dns
 spec: {}
 status:
-  versions:
-    - name: operator
-      version: "0.0.1-snapshot"
+ # status is set at runtime

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -3,8 +3,12 @@ package operator
 // Config is configuration for the operator and should include things like
 // operated images, scheduling configuration, etc.
 type Config struct {
+	// OperatorReleaseVersion is the current version of the operator.
+	OperatorReleaseVersion string
+
 	// CoreDNSImage is the CoreDNS image to manage.
 	CoreDNSImage string
+
 	// OpenshiftCLIImage is the openshift client image to manage.
 	OpenshiftCLIImage string
 }

--- a/pkg/stub/status.go
+++ b/pkg/stub/status.go
@@ -2,7 +2,6 @@ package stub
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -66,14 +65,14 @@ func (h *Handler) syncOperatorStatus() {
 	}
 
 	oldVersions := co.Status.Versions
-	if releaseVersion := os.Getenv("RELEASE_VERSION"); len(releaseVersion) > 0 {
+	if len(h.Config.OperatorReleaseVersion) > 0 {
 		// an available operator resets release version
 		for _, condition := range co.Status.Conditions {
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionTrue {
 				co.Status.Versions = []configv1.OperandVersion{
 					{
 						Name:    "operator",
-						Version: releaseVersion,
+						Version: h.Config.OperatorReleaseVersion,
 					},
 					{
 						Name:    "coredns",

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,0 @@
-package version
-
-var (
-	Version = "0.0.1"
-)


### PR DESCRIPTION
- Removed version/version.go, no longer used.

Follow up pr for https://github.com/openshift/cluster-dns-operator/pull/78