### PR TITLE
Bug 1690342: Initial DNS status conditions implementation

### DIFF
--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -382,31 +382,12 @@ func (r *reconciler) ensureDNS(dns *operatorv1.DNS) error {
 			errs = append(errs, fmt.Errorf("failed to integrate metrics with openshift-monitoring for dns %s: %v", dns.Name, err))
 		}
 
-		if err := r.syncDNSStatus(dns, clusterIP, clusterDomain); err != nil {
+		if err := r.syncDNSStatus(dns, clusterIP, clusterDomain, daemonset); err != nil {
 			errs = append(errs, fmt.Errorf("failed to sync status of dns %s/%s: %v", daemonset.Namespace, daemonset.Name, err))
 		}
 	}
 
 	return utilerrors.NewAggregate(errs)
-}
-
-// syncDNSStatus updates the status for a given dns.
-func (r *reconciler) syncDNSStatus(dns *operatorv1.DNS, clusterIP, clusterDomain string) error {
-	current := &operatorv1.DNS{}
-	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: dns.Name}, current); err != nil {
-		return fmt.Errorf("failed to get dns %s: %v", dns.Name, err)
-	}
-	if current.Status.ClusterIP == clusterIP &&
-		current.Status.ClusterDomain == clusterDomain {
-		return nil
-	}
-	current.Status.ClusterIP = clusterIP
-	current.Status.ClusterDomain = clusterDomain
-
-	if err := r.client.Status().Update(context.TODO(), current); err != nil {
-		return fmt.Errorf("failed to update status for dns %s: %v", current.Name, err)
-	}
-	return nil
 }
 
 // getClusterIPFromNetworkConfig will return 10th IP from the service CIDR range

--- a/pkg/operator/controller/dns_status.go
+++ b/pkg/operator/controller/dns_status.go
@@ -1,0 +1,170 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// syncDNSStatus computes the current status of dns and
+// updates status upon any changes since last sync.
+func (r *reconciler) syncDNSStatus(dns *operatorv1.DNS, clusterIP, clusterDomain string, ds *appsv1.DaemonSet) error {
+	updated := dns.DeepCopy()
+	updated.Status.ClusterIP = clusterIP
+	updated.Status.ClusterDomain = clusterDomain
+	updated.Status.Conditions = r.computeDNSStatusConditions(dns.Status.Conditions, clusterIP, ds)
+	if !dnsStatusesEqual(updated.Status, dns.Status) {
+		if err := r.client.Status().Update(context.TODO(), updated); err != nil {
+			return fmt.Errorf("failed to update dns status: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// computeDNSStatusConditions computes dns status conditions based on
+// the status of ds and clusterIP.
+func (r *reconciler) computeDNSStatusConditions(oldConditions []operatorv1.OperatorCondition, clusterIP string,
+	ds *appsv1.DaemonSet) []operatorv1.OperatorCondition {
+	var oldDegradedCondition, oldProgressingCondition, oldAvailableCondition *operatorv1.OperatorCondition
+	for i := range oldConditions {
+		switch oldConditions[i].Type {
+		case operatorv1.OperatorStatusTypeDegraded:
+			oldDegradedCondition = &oldConditions[i]
+		case operatorv1.OperatorStatusTypeProgressing:
+			oldProgressingCondition = &oldConditions[i]
+		case operatorv1.OperatorStatusTypeAvailable:
+			oldAvailableCondition = &oldConditions[i]
+		}
+	}
+
+	conditions := []operatorv1.OperatorCondition{
+		computeDNSDegradedCondition(oldDegradedCondition, clusterIP, ds),
+		computeDNSProgressingCondition(oldProgressingCondition, ds),
+		computeDNSAvailableCondition(oldAvailableCondition, clusterIP, ds),
+	}
+
+	return conditions
+}
+
+// computeDNSDegradedCondition computes the dns Degraded status condition
+// based on the status of clusterIP and ds.
+func computeDNSDegradedCondition(oldCondition *operatorv1.OperatorCondition, clusterIP string,
+	ds *appsv1.DaemonSet) operatorv1.OperatorCondition {
+	degradedCondition := &operatorv1.OperatorCondition{
+		Type: operatorv1.OperatorStatusTypeDegraded,
+	}
+	switch {
+	case len(clusterIP) == 0 && ds.Status.NumberAvailable == 0:
+		degradedCondition.Status = operatorv1.ConditionTrue
+		degradedCondition.Reason = "NoClusterIPAndDaemonSet"
+		degradedCondition.Message = "No ClusterIP assigned to DNS Service and no DaemonSet pods running"
+	case len(clusterIP) == 0:
+		degradedCondition.Status = operatorv1.ConditionTrue
+		degradedCondition.Reason = "NoClusterIP"
+		degradedCondition.Message = "No ClusterIP assigned to DNS Service"
+	case ds.Status.NumberAvailable == 0:
+		degradedCondition.Status = operatorv1.ConditionTrue
+		degradedCondition.Reason = "DaemonSetUnavailable"
+		degradedCondition.Message = "DaemonSet pod not running on any Nodes"
+	case ds.Status.NumberAvailable != ds.Status.DesiredNumberScheduled:
+		degradedCondition.Status = operatorv1.ConditionTrue
+		degradedCondition.Reason = "DaemonSetDegraded"
+		degradedCondition.Message = "Not all Nodes running DaemonSet pod"
+	default:
+		degradedCondition.Status = operatorv1.ConditionFalse
+		degradedCondition.Reason = "AsExpected"
+		degradedCondition.Message = "ClusterIP assigned to DNS Service and minimum DaemonSet pods running"
+	}
+
+	return setDNSLastTransitionTime(degradedCondition, oldCondition)
+}
+
+// computeDNSProgressingCondition computes the dns Progressing status condition
+// based on the status of ds.
+func computeDNSProgressingCondition(oldCondition *operatorv1.OperatorCondition, ds *appsv1.DaemonSet) operatorv1.OperatorCondition {
+	progressingCondition := &operatorv1.OperatorCondition{
+		Type: operatorv1.OperatorStatusTypeProgressing,
+	}
+	if ds.Status.NumberAvailable == ds.Status.DesiredNumberScheduled {
+		progressingCondition.Status = operatorv1.ConditionFalse
+		progressingCondition.Reason = "AsExpected"
+		progressingCondition.Message = "All expected Nodes running DaemonSet pod"
+	} else {
+		progressingCondition.Status = operatorv1.ConditionTrue
+		progressingCondition.Reason = "Reconciling"
+		progressingCondition.Message = fmt.Sprintf("%d Nodes running a DaemonSet pod, want %d",
+			ds.Status.NumberAvailable, ds.Status.DesiredNumberScheduled)
+	}
+
+	return setDNSLastTransitionTime(progressingCondition, oldCondition)
+}
+
+// computeDNSAvailableCondition computes the dns Available status condition
+// based on the status of clusterIP and ds.
+func computeDNSAvailableCondition(oldCondition *operatorv1.OperatorCondition, clusterIP string, ds *appsv1.DaemonSet) operatorv1.OperatorCondition {
+	availableCondition := &operatorv1.OperatorCondition{
+		Type: operatorv1.OperatorStatusTypeAvailable,
+	}
+	switch {
+	case len(clusterIP) == 0 && ds.Status.NumberAvailable == 0:
+		availableCondition.Status = operatorv1.ConditionFalse
+		availableCondition.Reason = "NoClusterIPAndDaemonSet"
+		availableCondition.Message = "No ClusterIP assigned to DNS Service and no running DaemonSet pods"
+	case len(clusterIP) == 0:
+		availableCondition.Status = operatorv1.ConditionFalse
+		availableCondition.Reason = "NoDNSService"
+		availableCondition.Message = "No ClusterIP assigned to DNS Service"
+	case ds.Status.NumberAvailable == 0:
+		availableCondition.Status = operatorv1.ConditionFalse
+		availableCondition.Reason = "DaemonSetUnavailable"
+		availableCondition.Message = "DaemonSet pod not running on any Nodes"
+	default:
+		availableCondition.Status = operatorv1.ConditionTrue
+		availableCondition.Reason = "AsExpected"
+		availableCondition.Message = "Minimum number of Nodes running DaemonSet pod"
+	}
+
+	return setDNSLastTransitionTime(availableCondition, oldCondition)
+}
+
+// setDNSLastTransitionTime sets LastTransitionTime for the given condition.
+// If the condition has changed, it will assign a new timestamp otherwise keeps the old timestamp.
+func setDNSLastTransitionTime(condition, oldCondition *operatorv1.OperatorCondition) operatorv1.OperatorCondition {
+	if oldCondition != nil && condition.Status == oldCondition.Status &&
+		condition.Reason == oldCondition.Reason && condition.Message == oldCondition.Message {
+		condition.LastTransitionTime = oldCondition.LastTransitionTime
+	} else {
+		condition.LastTransitionTime = metav1.Now()
+	}
+
+	return *condition
+}
+
+// dnsStatusesEqual compares two DNSStatus values.  Returns true
+// if the provided values should be considered equal for the purpose of determining
+// whether an update is necessary, false otherwise.
+func dnsStatusesEqual(a, b operatorv1.DNSStatus) bool {
+	conditionCmpOpts := []cmp.Option{
+		cmpopts.EquateEmpty(),
+		cmpopts.SortSlices(func(a, b operatorv1.OperatorCondition) bool { return a.Type < b.Type }),
+	}
+	if !cmp.Equal(a.Conditions, b.Conditions, conditionCmpOpts...) {
+		return false
+	}
+	if a.ClusterIP != b.ClusterIP {
+		return false
+	}
+	if a.ClusterDomain != b.ClusterDomain {
+		return false
+	}
+
+	return true
+}

--- a/pkg/operator/controller/dns_status_test.go
+++ b/pkg/operator/controller/dns_status_test.go
@@ -1,0 +1,304 @@
+package controller
+
+import (
+	"fmt"
+	"testing"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var r reconciler
+
+func TestDNSStatusConditions(t *testing.T) {
+	type testInputs struct {
+		haveClusterIP bool
+		avail, desire int32
+	}
+	type testOutputs struct {
+		degraded, progressing, available bool
+	}
+	testCases := []struct {
+		description string
+		inputs      testInputs
+		outputs     testOutputs
+	}{
+		{
+			description: "no cluster ip, 0/0 pods available",
+			inputs:      testInputs{false, 0, 0},
+			outputs:     testOutputs{true, false, false},
+		},
+		{
+			description: "no cluster ip, 0/2 pods available",
+			inputs:      testInputs{false, 0, 2},
+			outputs:     testOutputs{true, true, false},
+		},
+		{
+			description: "no cluster ip, 1/2 pods available",
+			inputs:      testInputs{false, 1, 2},
+			outputs:     testOutputs{true, true, false},
+		},
+		{
+			description: "no cluster ip, 2/2 pods available",
+			inputs:      testInputs{false, 2, 2},
+			outputs:     testOutputs{true, false, false},
+		},
+		{
+			description: "daemonset pod available on 0/0 nodes",
+			inputs:      testInputs{true, 0, 0},
+			outputs:     testOutputs{true, false, false},
+		},
+		{
+			description: "daemonset pod available on 0/2 nodes",
+			inputs:      testInputs{true, 0, 2},
+			outputs:     testOutputs{true, true, false},
+		},
+		{
+			description: "daemonset pod available on 1/2 nodes",
+			inputs:      testInputs{true, 1, 2},
+			outputs:     testOutputs{true, true, true},
+		},
+		{
+			description: "daemonset pod available on 2/2 nodes",
+			inputs:      testInputs{true, 2, 2},
+			outputs:     testOutputs{false, false, true},
+		},
+	}
+
+	for i, tc := range testCases {
+		var (
+			clusterIP string
+
+			degraded, progressing, available operatorv1.ConditionStatus
+		)
+		if tc.inputs.haveClusterIP {
+			clusterIP = "1.2.3.4"
+		}
+		ds := &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("dns-%d", i+1),
+			},
+			Status: appsv1.DaemonSetStatus{
+				DesiredNumberScheduled: tc.inputs.desire,
+				NumberAvailable:        tc.inputs.avail,
+			},
+		}
+		if tc.outputs.degraded {
+			degraded = operatorv1.ConditionTrue
+		} else {
+			degraded = operatorv1.ConditionFalse
+		}
+		if tc.outputs.progressing {
+			progressing = operatorv1.ConditionTrue
+		} else {
+			progressing = operatorv1.ConditionFalse
+		}
+		if tc.outputs.available {
+			available = operatorv1.ConditionTrue
+		} else {
+			available = operatorv1.ConditionFalse
+		}
+		expected := []operatorv1.OperatorCondition{
+			{
+				Type:   operatorv1.OperatorStatusTypeDegraded,
+				Status: degraded,
+			},
+			{
+				Type:   operatorv1.OperatorStatusTypeProgressing,
+				Status: progressing,
+			},
+			{
+				Type:   operatorv1.OperatorStatusTypeAvailable,
+				Status: available,
+			},
+		}
+		actual := r.computeDNSStatusConditions([]operatorv1.OperatorCondition{}, clusterIP, ds)
+		gotExpected := true
+		if len(actual) != len(expected) {
+			gotExpected = false
+		}
+		for _, conditionA := range actual {
+			foundMatchingCondition := false
+
+			for _, conditionB := range expected {
+				if conditionA.Type == conditionB.Type &&
+					conditionA.Status == conditionB.Status {
+					foundMatchingCondition = true
+					break
+				}
+			}
+
+			if !foundMatchingCondition {
+				gotExpected = false
+			}
+		}
+		if !gotExpected {
+			t.Fatalf("%q: expected %#v, got %#v", tc.description,
+				expected, actual)
+		}
+	}
+}
+
+func TestDNSStatusesEqual(t *testing.T) {
+	testCases := []struct {
+		description string
+		expected    bool
+		a, b        operatorv1.DNSStatus
+	}{
+		{
+			description: "nil and non-nil slices are equal",
+			expected:    true,
+			a: operatorv1.DNSStatus{
+				Conditions: []operatorv1.OperatorCondition{},
+			},
+		},
+		{
+			description: "empty slices should be equal",
+			expected:    true,
+			a: operatorv1.DNSStatus{
+				Conditions: []operatorv1.OperatorCondition{},
+			},
+			b: operatorv1.DNSStatus{
+				Conditions: []operatorv1.OperatorCondition{},
+			},
+		},
+		{
+			description: "condition LastTransitionTime should not be ignored",
+			expected:    false,
+			a: operatorv1.DNSStatus{
+				Conditions: []operatorv1.OperatorCondition{
+					{
+						Type:               operatorv1.OperatorStatusTypeAvailable,
+						Status:             operatorv1.ConditionTrue,
+						LastTransitionTime: metav1.Unix(0, 0),
+					},
+				},
+			},
+			b: operatorv1.DNSStatus{
+				Conditions: []operatorv1.OperatorCondition{
+					{
+						Type:               operatorv1.OperatorStatusTypeAvailable,
+						Status:             operatorv1.ConditionTrue,
+						LastTransitionTime: metav1.Unix(1, 0),
+					},
+				},
+			},
+		},
+		{
+			description: "condition differs",
+			expected:    false,
+			a: operatorv1.DNSStatus{
+				Conditions: []operatorv1.OperatorCondition{
+					{
+						Type:   operatorv1.OperatorStatusTypeAvailable,
+						Status: operatorv1.ConditionTrue,
+					},
+				},
+			},
+			b: operatorv1.DNSStatus{
+				Conditions: []operatorv1.OperatorCondition{
+					{
+						Type:   operatorv1.OperatorStatusTypeDegraded,
+						Status: operatorv1.ConditionTrue,
+					},
+				},
+			},
+		},
+		{
+			description: "check condition reason differs",
+			expected:    false,
+			a: operatorv1.DNSStatus{
+				Conditions: []operatorv1.OperatorCondition{
+					{
+						Type:   operatorv1.OperatorStatusTypeAvailable,
+						Status: operatorv1.ConditionFalse,
+						Reason: "foo",
+					},
+				},
+			},
+			b: operatorv1.DNSStatus{
+				Conditions: []operatorv1.OperatorCondition{
+					{
+						Type:   operatorv1.OperatorStatusTypeAvailable,
+						Status: operatorv1.ConditionFalse,
+						Reason: "bar",
+					},
+				},
+			},
+		},
+		{
+			description: "check condition message differs",
+			expected:    false,
+			a: operatorv1.DNSStatus{
+				Conditions: []operatorv1.OperatorCondition{
+					{
+						Type:    operatorv1.OperatorStatusTypeAvailable,
+						Status:  operatorv1.ConditionFalse,
+						Message: "foo",
+					},
+				},
+			},
+			b: operatorv1.DNSStatus{
+				Conditions: []operatorv1.OperatorCondition{
+					{
+						Type:    operatorv1.OperatorStatusTypeAvailable,
+						Status:  operatorv1.ConditionFalse,
+						Message: "bar",
+					},
+				},
+			},
+		},
+		{
+			description: "condition status differs",
+			expected:    false,
+			a: operatorv1.DNSStatus{
+				Conditions: []operatorv1.OperatorCondition{
+					{
+						Type:   operatorv1.OperatorStatusTypeProgressing,
+						Status: operatorv1.ConditionTrue,
+					},
+				},
+			},
+			b: operatorv1.DNSStatus{
+				Conditions: []operatorv1.OperatorCondition{
+					{
+						Type:   operatorv1.OperatorStatusTypeProgressing,
+						Status: operatorv1.ConditionFalse,
+					},
+				},
+			},
+		},
+		{
+			description: "check duplicate with single condition",
+			expected:    false,
+			a: operatorv1.DNSStatus{
+				Conditions: []operatorv1.OperatorCondition{
+					{
+						Type:    operatorv1.OperatorStatusTypeAvailable,
+						Message: "foo",
+					},
+				},
+			},
+			b: operatorv1.DNSStatus{
+				Conditions: []operatorv1.OperatorCondition{
+					{
+						Type:    operatorv1.OperatorStatusTypeAvailable,
+						Message: "foo",
+					},
+					{
+						Type:    operatorv1.OperatorStatusTypeAvailable,
+						Message: "foo",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		if actual := dnsStatusesEqual(tc.a, tc.b); actual != tc.expected {
+			t.Fatalf("%q: expected %v, got %v", tc.description, tc.expected, actual)
+		}
+	}
+}

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -44,7 +44,7 @@ func TestOperatorAvailable(t *testing.T) {
 
 	err = wait.PollImmediate(1*time.Second, 5*time.Minute, func() (bool, error) {
 		co := &configv1.ClusterOperator{}
-		if err := cl.Get(context.TODO(), types.NamespacedName{Name: operatorcontroller.DNSClusterOperatorName}, co); err != nil {
+		if err := cl.Get(context.TODO(), types.NamespacedName{Name: operatorcontroller.DNSOperatorName}, co); err != nil {
 			return false, nil
 		}
 
@@ -125,7 +125,7 @@ func TestVersionReporting(t *testing.T) {
 
 	err = wait.PollImmediate(1*time.Second, 5*time.Minute, func() (bool, error) {
 		co := &configv1.ClusterOperator{}
-		if err := cl.Get(context.TODO(), types.NamespacedName{Name: operatorcontroller.DNSClusterOperatorName}, co); err != nil {
+		if err := cl.Get(context.TODO(), types.NamespacedName{Name: operatorcontroller.DNSOperatorName}, co); err != nil {
 			return false, nil
 		}
 


### PR DESCRIPTION
Previously, status conditions for the `dns.operator.openshift.io/v1` resource were not implemented.

This commit does the following:

- Implements `Degraded`, `Progressing` and `Available` status conditions for `dns.operator.openshift.io/v1`.
- Refactors cluster-dns-operator `Degraded` status condition to be calculated from the the availability of `ClusterIP`.
- Refactors cluster-dns-operator `Progressing` and `Available` status conditions to be calculated from the `dns.operator.openshift.io/v1` `Available` condition.
- Replaces deployment logic from cluster-dns-operator unit tests with `dns.operator.openshift.io/v1` `Available` conditions.
- Adds `dns.operator.openshift.io/v1` status condition unit tests.