### PR TITLE
Removes static GOOS reference from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,8 @@ BIN=$(lastword $(subst /, ,$(MAIN_PACKAGE)))
 
 IMAGE_TAG=openshift/origin-cluster-dns-operator
 
-ENVVAR=GOOS=linux CGO_ENABLED=0
-GOOS=linux
-GO_BUILD_RECIPE=GOOS=$(GOOS) go build -o $(BIN) $(MAIN_PACKAGE)
+ENVVAR=CGO_ENABLED=0
+GO_BUILD_RECIPE=go build -o $(BIN) $(MAIN_PACKAGE)
 
 .PHONY: build
 build:


### PR DESCRIPTION
Previously, `make build` would only build the cluster dns operator bin for linux. This prevents dev's from building and running the operator on a non-Linux machine.

This commit removes static `GOOS=linx` Makefile references, allowing the build to use the local OS. Additionally, this provides parity with the cluster-ingress-operator.

/hold