### PR TITLE
Delete registration of client-go GCP auth plug-in

### DIFF
--- a/cmd/dns-operator/main.go
+++ b/cmd/dns-operator/main.go
@@ -6,8 +6,6 @@ import (
 	"github.com/openshift/cluster-dns-operator/pkg/operator"
 	operatorconfig "github.com/openshift/cluster-dns-operator/pkg/operator/config"
 
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-
 	"github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/controller-runtime/pkg/metrics"


### PR DESCRIPTION
This import was added accidentally.

* `cmd/dns-operator/main.go`: Delete import of the client-go GCP auth plug-in.