### PR TITLE
Bug 1705032: Fix updating versions for dns cluster operator

### DIFF
--- a/cmd/dns-operator/main.go
+++ b/cmd/dns-operator/main.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/openshift/cluster-dns-operator/pkg/operator"
 	operatorconfig "github.com/openshift/cluster-dns-operator/pkg/operator/config"
+	"github.com/openshift/cluster-dns-operator/pkg/operator/controller"
 
 	"github.com/sirupsen/logrus"
 
@@ -16,6 +17,11 @@ func main() {
 	metrics.DefaultBindAddress = ":60000"
 
 	// Collect operator configuration.
+	releaseVersion := os.Getenv("RELEASE_VERSION")
+	if len(releaseVersion) == 0 {
+		releaseVersion = controller.UnknownVersionValue
+		logrus.Infof("RELEASE_VERSION environment variable is missing, defaulting to %q", controller.UnknownVersionValue)
+	}
 	coreDNSImage := os.Getenv("IMAGE")
 	if len(coreDNSImage) == 0 {
 		logrus.Fatalf("IMAGE environment variable is required")
@@ -26,7 +32,7 @@ func main() {
 	}
 
 	operatorConfig := operatorconfig.Config{
-		OperatorReleaseVersion: os.Getenv("RELEASE_VERSION"),
+		OperatorReleaseVersion: releaseVersion,
 		CoreDNSImage:           coreDNSImage,
 		OpenshiftCLIImage:      cliImage,
 	}

--- a/manifests/0000_70_dns-operator_03-cluster-operator.yaml
+++ b/manifests/0000_70_dns-operator_03-cluster-operator.yaml
@@ -1,7 +1,8 @@
+# This resource is not created by CVO, it is only used as a communication
+# mechanism to tell the CVO which ClusterOperator resource to wait for.
+# DNS operator creates and updates this resource.
 apiVersion: config.openshift.io/v1
 kind: ClusterOperator
 metadata:
   name: dns
 spec: {}
-status:
- # status is set at runtime


### PR DESCRIPTION
- Always report 'operator' version irrespective of available condition.

- For upgrades, report old versions until the new version is fully applied.