### PR TITLE
Fixes operator deployment filename in release-local.sh

### DIFF
--- a/hack/release-local.sh
+++ b/hack/release-local.sh
@@ -29,7 +29,7 @@ if [[ "${TEMP_COMMIT}" == "true" ]]; then
 fi
 
 cp -R manifests/* $MANIFESTS
-cat manifests/0000_08_dns-operator_02-deployment.yaml | sed "s~openshift/origin-cluster-dns-operator:latest~$REPO:$REV~" > "$MANIFESTS/0000_08_dns-operator_02-deployment.yaml"
+cat manifests/0000_70_dns-operator_02-deployment.yaml | sed "s~openshift/origin-cluster-dns-operator:latest~$REPO:$REV~" > "$MANIFESTS/0000_70_dns-operator_02-deployment.yaml"
 
 echo "Pushed $REPO:$REV"
 echo "Install manifests using:"


### PR DESCRIPTION
https://github.com/openshift/cluster-dns-operator/pull/101 introduced a bug by updating the operator deployment manifest filename without updating the reference in release-local.sh. This PR updates the filename in release-local.sh, allowing local releases to properly build