### PR TITLE
Removes receiver from computeDNSStatusConditions func

### DIFF
--- a/pkg/operator/controller/dns_status.go
+++ b/pkg/operator/controller/dns_status.go
@@ -19,7 +19,7 @@ func (r *reconciler) syncDNSStatus(dns *operatorv1.DNS, clusterIP, clusterDomain
 	updated := dns.DeepCopy()
 	updated.Status.ClusterIP = clusterIP
 	updated.Status.ClusterDomain = clusterDomain
-	updated.Status.Conditions = r.computeDNSStatusConditions(dns.Status.Conditions, clusterIP, ds)
+	updated.Status.Conditions = computeDNSStatusConditions(dns.Status.Conditions, clusterIP, ds)
 	if !dnsStatusesEqual(updated.Status, dns.Status) {
 		if err := r.client.Status().Update(context.TODO(), updated); err != nil {
 			return fmt.Errorf("failed to update dns status: %v", err)
@@ -31,7 +31,7 @@ func (r *reconciler) syncDNSStatus(dns *operatorv1.DNS, clusterIP, clusterDomain
 
 // computeDNSStatusConditions computes dns status conditions based on
 // the status of ds and clusterIP.
-func (r *reconciler) computeDNSStatusConditions(oldConditions []operatorv1.OperatorCondition, clusterIP string,
+func computeDNSStatusConditions(oldConditions []operatorv1.OperatorCondition, clusterIP string,
 	ds *appsv1.DaemonSet) []operatorv1.OperatorCondition {
 	var oldDegradedCondition, oldProgressingCondition, oldAvailableCondition *operatorv1.OperatorCondition
 	for i := range oldConditions {

--- a/pkg/operator/controller/dns_status_test.go
+++ b/pkg/operator/controller/dns_status_test.go
@@ -10,8 +10,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var r reconciler
-
 func TestDNSStatusConditions(t *testing.T) {
 	type testInputs struct {
 		haveClusterIP bool
@@ -114,7 +112,7 @@ func TestDNSStatusConditions(t *testing.T) {
 				Status: available,
 			},
 		}
-		actual := r.computeDNSStatusConditions([]operatorv1.OperatorCondition{}, clusterIP, ds)
+		actual := computeDNSStatusConditions([]operatorv1.OperatorCondition{}, clusterIP, ds)
 		gotExpected := true
 		if len(actual) != len(expected) {
 			gotExpected = false


### PR DESCRIPTION
https://github.com/openshift/cluster-dns-operator/pull/88 added dns status conditions. Initially the PR included status.version as part of the Progressing condition calculation, which required `computeDNSStatusConditions` to contain a reconciler pointer receiver. It was later decided to include status.version calculation in a separate PR, but the pointer was not removed.