### PR TITLE
Fix hack/release.sh: Skip ClusterOperator resource creation

### DIFF
--- a/hack/release-local.sh
+++ b/hack/release-local.sh
@@ -30,6 +30,8 @@ fi
 
 cp -R manifests/* $MANIFESTS
 cat manifests/0000_70_dns-operator_02-deployment.yaml | sed "s~openshift/origin-cluster-dns-operator:latest~$REPO:$REV~" > "$MANIFESTS/0000_70_dns-operator_02-deployment.yaml"
+# To simulate CVO, ClusterOperator resource need to be created by the operator.
+rm $MANIFESTS/0000_70_dns-operator_03-cluster-operator.yaml
 
 echo "Pushed $REPO:$REV"
 echo "Install manifests using:"

--- a/manifests/0000_70_dns-operator_03-cluster-operator.yaml
+++ b/manifests/0000_70_dns-operator_03-cluster-operator.yaml
@@ -5,4 +5,3 @@ apiVersion: config.openshift.io/v1
 kind: ClusterOperator
 metadata:
   name: dns
-spec: {}


### PR DESCRIPTION
- As per the spec[1], ClusterOperator resource must be created by the operator.

[1] https://github.com/openshift/cluster-version-operator/blob/master/docs/dev/clusteroperator.md#how-clusterversionoperator-handles-clusteroperator-in-release-imagehttps://github.com/openshift/cluster-version-operator/blob/master/docs/dev/clusteroperator.md#how-clusterversionoperator-handles-clusteroperator-in-release-image