### PR TITLE
Dockerfile.rhel7: Use golang-1.12

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
 WORKDIR /dns-operator
 COPY . .
 RUN make build


### PR DESCRIPTION
Follow-up to https://github.com/openshift/cluster-dns-operator/pull/115.

* `Dockerfile.rhel7`: Use the golang-1.12 builder image.