### PR TITLE
NE-76: Integrate operator metrics with Prometheus

### DIFF
--- a/manifests/0000_70_dns-operator_00-cluster-role.yaml
+++ b/manifests/0000_70_dns-operator_00-cluster-role.yaml
@@ -47,6 +47,20 @@ rules:
   - get
 
 - apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterroles

--- a/manifests/0000_70_dns-operator_00-namespace.yaml
+++ b/manifests/0000_70_dns-operator_00-namespace.yaml
@@ -7,3 +7,5 @@ metadata:
   labels:
     # set value to avoid depending on kube admission that depends on openshift apis
     openshift.io/run-level: "0"
+    # allow openshift-monitoring to look for ServiceMonitor objects in this namespace
+    openshift.io/cluster-monitoring: "true"

--- a/manifests/0000_70_dns-operator_01-service.yaml
+++ b/manifests/0000_70_dns-operator_01-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: metrics-tls
+  labels:
+    name: dns-operator
+  name: metrics
+  namespace: openshift-dns-operator
+spec:
+  ports:
+  - name: metrics
+    port: 9393
+    targetPort: metrics
+  selector:
+    name: dns-operator
+  type: ClusterIP

--- a/manifests/0000_70_dns-operator_02-deployment.yaml
+++ b/manifests/0000_70_dns-operator_02-deployment.yaml
@@ -36,6 +36,30 @@ spec:
         resources:
           requests:
             cpu: 10m
+      - name: kube-rbac-proxy
+        image: quay.io/openshift/origin-kube-rbac-proxy:latest
+        args:
+        - --logtostderr
+        - --secure-listen-address=:9393
+        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+        - --upstream=http://127.0.0.1:60000/
+        - --tls-cert-file=/etc/tls/private/tls.crt
+        - --tls-private-key-file=/etc/tls/private/tls.key
+        ports:
+        - containerPort: 9393
+          name: metrics
+        resources:
+          requests:
+            cpu: 10m
+            memory: 40Mi
+        volumeMounts:
+        - mountPath: /etc/tls/private
+          name: metrics-tls
+          readOnly: true
+      volumes:
+      - name: metrics-tls
+        secret:
+          secretName: metrics-tls
       terminationGracePeriodSeconds: 2
       tolerations:
       - key: "node-role.kubernetes.io/master"

--- a/manifests/0000_90_dns-operator_00_prometheusrole.yaml
+++ b/manifests/0000_90_dns-operator_00_prometheusrole.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-dns-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch

--- a/manifests/0000_90_dns-operator_01_prometheusrolebinding.yaml
+++ b/manifests/0000_90_dns-operator_01_prometheusrolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-dns-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/manifests/0000_90_dns-operator_02_servicemonitor.yaml
+++ b/manifests/0000_90_dns-operator_02_servicemonitor.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: dns-operator
+  namespace: openshift-dns-operator
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    port: metrics
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: metrics.openshift-dns-operator.svc
+  jobLabel: component
+  selector:
+    matchLabels:
+      name: dns-operator

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -14,3 +14,7 @@ spec:
     from:
       kind: "DockerImage"
       name: "openshift/origin-cli:v4.0"
+  - name: kube-rbac-proxy
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-kube-rbac-proxy:latest


### PR DESCRIPTION
The operator exposes metrics, but they are not collected.  Configure Prometheus to collect these metrics.

* `manifests/0000_70_dns-operator_00-namespace.yaml`: Add a label for `openshift-monitoring`.
* `manifests/0000_70_dns-operator_02-deployment.yaml`: Add the metrics port.
* `manifests/0000_70_dns-operator_04-service.yaml`: New file.  Define a metrics service.
* `manifests/0000_90_dns-operator_00_prometheusrole.yaml`:  New file.  Define a role that grants access to services, endpoints, and pods.
* `manifests/0000_90_dns-operator_01_prometheusrolebinding.yaml`:  New file.  Bind the `prometheus-k8s` service account to the new role.
* `manifests/0000_90_dns-operator_02_servicemonitor.yaml`: New file.  Define a service monitor for the new service.