### PR TITLE
Bug 1722341: remove duplicate toleration key from operator deployment

### DIFF
--- a/manifests/0000_70_dns-operator_02-deployment.yaml
+++ b/manifests/0000_70_dns-operator_02-deployment.yaml
@@ -48,6 +48,3 @@ spec:
       - key: "node.kubernetes.io/not-ready"
         operator: "Exists"
         effect: "NoExecute"
-      - key: "node.kubernetes.io/not-ready"
-        operator: "Exists"
-        effect: "NoSchedule"

--- a/manifests/0000_70_dns-operator_02-deployment.yaml
+++ b/manifests/0000_70_dns-operator_02-deployment.yaml
@@ -48,3 +48,4 @@ spec:
       - key: "node.kubernetes.io/not-ready"
         operator: "Exists"
         effect: "NoExecute"
+        tolerationSeconds: 120


### PR DESCRIPTION
Remove a redundant 'node.kubernetes.io/not-ready' toleration on the operator
deployment manifest.