### PR TITLE
syncOperatorStatus: Simplify relatedObjects

### DIFF
--- a/pkg/operator/controller/status.go
+++ b/pkg/operator/controller/status.go
@@ -71,14 +71,12 @@ func (r *reconciler) syncOperatorStatus() error {
 			Resource: "namespaces",
 			Name:     ns.Name,
 		},
-	}
-	for _, dns := range dnses {
-		related = append(related, configv1.ObjectReference{
+		{
 			Group:    operatorv1.GroupName,
 			Resource: "DNS",
-			Name:     dns.Name,
-		})
+		},
 	}
+
 	co.Status.RelatedObjects = related
 
 	dnsStatusConditionsCounts := computeDNSStatusConditionCounts(dnses)

--- a/pkg/operator/controller/status.go
+++ b/pkg/operator/controller/status.go
@@ -76,7 +76,6 @@ func (r *reconciler) syncOperatorStatus() error {
 			Resource: "DNS",
 		},
 	}
-
 	co.Status.RelatedObjects = related
 
 	dnsStatusConditionsCounts := computeDNSStatusConditionCounts(dnses)


### PR DESCRIPTION
Simplify relatedObjects computation by omitting resource names.

https://jira.coreos.com/browse/NE-218