### PR TITLE
WIP: metrics: Add metrics with number of total dnses, dnses using forwarding API

### DIFF
--- a/pkg/operator/controller/metrics/metrics.go
+++ b/pkg/operator/controller/metrics/metrics.go
@@ -1,0 +1,46 @@
+package metrics
+
+import (
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	// DNSesTotal is a Prometheus gauge metric which holds the total number
+	// of DNSes.
+	DNSesTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "dns_operator_dnses_total",
+		Help: "Total number of DNSes",
+	}, []string{"dnses"})
+
+	// DNSesUsingForwardingAPI is a Prometheus gauge metric which indicates
+	// how many DNS operands are using the Forwarding API.
+	DNSesUsingForwardingAPI = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "dns_operator_dnses_using_forwarding_api",
+		Help: "Number of DNSes using the forwarding API",
+	}, []string{"dnses"})
+)
+
+func Update(dnses []operatorv1.DNS) {
+	DNSesTotal.WithLabelValues("dnses").Set(float64(len(dnses)))
+
+	numUsingForwarding := 0
+	for _, dns := range dnses {
+		for _, server := range dns.Spec.Servers {
+			if len(server.ForwardPlugin.Upstreams) > 0 {
+				numUsingForwarding++
+				break
+			}
+		}
+	}
+	DNSesUsingForwardingAPI.WithLabelValues("dnses").Set(float64(numUsingForwarding))
+}
+
+func init() {
+	metrics.Registry.MustRegister(
+		DNSesTotal,
+		DNSesUsingForwardingAPI,
+	)
+}

--- a/pkg/operator/controller/status.go
+++ b/pkg/operator/controller/status.go
@@ -12,6 +12,7 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 
 	"github.com/openshift/cluster-dns-operator/pkg/manifests"
+	"github.com/openshift/cluster-dns-operator/pkg/operator/controller/metrics"
 
 	"github.com/sirupsen/logrus"
 
@@ -61,6 +62,8 @@ func (r *reconciler) syncOperatorStatus() error {
 	if err != nil {
 		return fmt.Errorf("failed to get operator state: %v", err)
 	}
+
+	metrics.Update(dnses)
 
 	related := []configv1.ObjectReference{
 		{


### PR DESCRIPTION
Add metrics with the number of dns resources and the number of dnses that are using the forwarding API.

* `pkg/operator/controller/metrics/metrics.go`: New file.
(`DNSesTotal`, `DNSesUsingForwardingAPI`): New metrics.
(`Update`): New function.  Update `DNSesTotal` and `DNSesUsingForwardingAPI` using the given slice of DNSes.
(`init`): Register `DNSesTotal` and `DNSesUsingForwardingAPI`.
* pkg/operator/controller/status.go (`syncOperatorStatus`): Call `metrics.Update`.

----

This PR has two purposes: (1) establish a pattern for adding operator metrics (@miheer, you were interested in this), and (2) provide visibility as to how many clusters actually use the new forwarding API (idea from @brenton).  @ironcladlou, what do you think?

I tested manually and verified in Prometheus that `dns_operator_dnses_using_forwarding_api` indeed shows 0 initially, 1 after I patch the `default` dns to use the new forwarding API, and 0 again if I subsequently patch the `default` dns resource's `spec.servers[0].forwardPlugin` field to `null`.  So it works.  Suggestions for better metrics names or other improvements are welcome.