### PR TITLE
Bug 1778529: daemonsetConfigChanged: Check tolerations

### DIFF
--- a/pkg/operator/controller/controller_dns_daemonset_test.go
+++ b/pkg/operator/controller/controller_dns_daemonset_test.go
@@ -64,6 +64,13 @@ func TestDesiredDNSDaemonset(t *testing.T) {
 	}
 }
 
+var toleration = corev1.Toleration{
+	Key:      "foo",
+	Value:    "bar",
+	Operator: corev1.TolerationOpExists,
+	Effect:   corev1.TaintEffectNoExecute,
+}
+
 func TestDaemonsetConfigChanged(t *testing.T) {
 	testCases := []struct {
 		description string
@@ -87,6 +94,13 @@ func TestDaemonsetConfigChanged(t *testing.T) {
 			mutate: func(daemonset *appsv1.DaemonSet) {
 				ns := map[string]string{"kubernetes.io/os": "linux"}
 				daemonset.Spec.Template.Spec.NodeSelector = ns
+			},
+			expect: true,
+		},
+		{
+			description: "if .spec.template.spec.tolerations changes",
+			mutate: func(daemonset *appsv1.DaemonSet) {
+				daemonset.Spec.Template.Spec.Tolerations = []corev1.Toleration{toleration}
 			},
 			expect: true,
 		},


### PR DESCRIPTION
Follow-up to #140.

* `pkg/operator/controller/controller_dns_daemonset.go` (`daemonsetConfigChanged`): Compare tolerations using go-cmp and the new `cmpTolerations` function.
(`cmpTolerations`): New function.
* `pkg/operator/controller/controller_dns_daemonset_test.go` (`toleration`): New variable.  Dummy toleration for testing.
(`TestDaemonsetConfigChanged`): Add a test case to verify that `deploymentConfigChanged` detects updates to `.spec.template.spec.tolerations`.


----

@ironcladlou