### PR TITLE
dns-node-resolver: Less racy clean-up of background jobs

### DIFF
--- a/assets/dns/daemonset.yaml
+++ b/assets/dns/daemonset.yaml
@@ -75,7 +75,7 @@ spec:
           #!/bin/bash
           set -uo pipefail
 
-          trap 'kill $(jobs -p); exit 0' TERM
+          trap 'jobs=($(jobs -p)); ((${#jobs})) && kill "${jobs[@]}" || true; exit 0' TERM
 
           OPENSHIFT_MARKER="openshift-generated-node-resolver"
           HOSTS_FILE="/etc/hosts"


### PR DESCRIPTION
Change the dns-node-resolver sidecar's clean-up handler to avoid issuing a `kill` command if no background jobs are found, and to ignore errors if the `kill` command fails.

Before this commit, the dns-node-resolver sidecar's clean-up handler could cause spurious error messages such as the following if background jobs exited in between execution of the command to list jobs and execution of the command to kill them:

    /bin/bash: line 1: kill: (123) - No such process

* `assets/dns/daemonset.yaml`: Fix dns-node-resolver's clean-up handler.