### PR TITLE
Bug 1813479: Tolerate all taints

### DIFF
--- a/assets/dns/daemonset.yaml
+++ b/assets/dns/daemonset.yaml
@@ -147,6 +147,5 @@ spec:
           path: /etc/hosts
           type: File
       tolerations:
-      # DNS needs to run everywhere.
-      - key: "node-role.kubernetes.io/master"
-        operator: Exists
+      # DNS needs to run everywhere. Tolerate all taints
+      - operator: Exists


### PR DESCRIPTION
This was changed for master only, but when using taints on infra nodes 
as described in opeshift docs, dns pods will no longer schedule in infra 
nodes.

See:
https://bugzilla.redhat.com/show_bug.cgi?id=1780318#

and

https://bugzilla.redhat.com/show_bug.cgi?id=1813479