### PR TITLE
Bug 1835725: computeOperatorDegradedCondition: Fix "NoDNS" check

### DIFF
--- a/pkg/operator/controller/status.go
+++ b/pkg/operator/controller/status.go
@@ -237,7 +237,7 @@ func computeOperatorDegradedCondition(oldCondition *configv1.ClusterOperatorStat
 		degradedCondition.Status = configv1.ConditionTrue
 		degradedCondition.Reason = "NoNamespace"
 		degradedCondition.Message = "Operand Namespace does not exist"
-	case dnses.available == 0:
+	case dnses.total == 0:
 		degradedCondition.Status = configv1.ConditionTrue
 		degradedCondition.Reason = "NoDNS"
 		degradedCondition.Message = "No DNS resource exists"


### PR DESCRIPTION
Follow-up to #109.

* `pkg/operator/controller/status.go` (`computeOperatorDegradedCondition`): Check total number of `dns` resources, not the available number, before reporting no DNS resource exists.

---

I noticed the erroneous error reporting in https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_router/113/pull-ci-openshift-router-master-e2e-aws/373:

```
level=error msg="Cluster operator dns Degraded is True with NoDNS: No DNS resource exists"
```

The operator's logs showed that it had created the resource, and CI artifacts showed that the daemonset existed but had no available replicas.