### PR TITLE
Bug 1826885: DNS Service Monitor & Daemonset fixes

### DIFF
--- a/pkg/operator/controller/controller_dns_daemonset.go
+++ b/pkg/operator/controller/controller_dns_daemonset.go
@@ -166,7 +166,7 @@ func daemonsetConfigChanged(current, expected *appsv1.DaemonSet) (bool, *appsv1.
 	changed := false
 	updated := current.DeepCopy()
 
-	for _, name := range []string{"dns", "dns-node-resolver"} {
+	for _, name := range []string{"dns", "dns-node-resolver", "kube-rbac-proxy"} {
 		var curIndex int
 		var curImage, expImage string
 

--- a/pkg/operator/controller/controller_dns_daemonset_test.go
+++ b/pkg/operator/controller/controller_dns_daemonset_test.go
@@ -135,6 +135,13 @@ func TestDaemonsetConfigChanged(t *testing.T) {
 			expect: true,
 		},
 		{
+			description: "if the kube rbac proxy image is changed",
+			mutate: func(daemonset *appsv1.DaemonSet) {
+				daemonset.Spec.Template.Spec.Containers[2].Image = "openshift/origin-kube-rbac-proxy:latest"
+			},
+			expect: true,
+		},
+		{
 			description: "if a container command length changed",
 			mutate: func(daemonset *appsv1.DaemonSet) {
 				daemonset.Spec.Template.Spec.Containers[1].Command = append(daemonset.Spec.Template.Spec.Containers[1].Command, "--foo")
@@ -175,6 +182,14 @@ func TestDaemonsetConfigChanged(t *testing.T) {
 								Command: []string{
 									"c",
 									"d",
+								},
+							},
+							{
+								Name:  "kube-rbac-proxy",
+								Image: "openshift/origin-kube-rbac-proxy:v4.0",
+								Command: []string{
+									"e",
+									"f",
 								},
 							},
 						},

--- a/pkg/operator/controller/controller_service_monitor_test.go
+++ b/pkg/operator/controller/controller_service_monitor_test.go
@@ -20,13 +20,13 @@ func TestDNSServiceMonitorChanged(t *testing.T) {
 		{
 			description: "if spec.endpoints.scheme changes",
 			mutate: func(serviceMonitor *unstructured.Unstructured) {
-				serviceMonitor.Object["spec"] = map[string]interface{}{
-					"selector": map[string]interface{}{},
-					"endpoints": []interface{}{
-						map[string]interface{}{
-							"scheme": "http",
-						},
-					},
+				spec := serviceMonitor.Object["spec"].(map[string]interface{})
+				endpoints := spec["endpoints"].([]interface{})
+				for x := range endpoints {
+					setting := endpoints[x].(map[string]interface{})
+					if setting["scheme"] != nil {
+						setting["scheme"] = "http"
+					}
 				}
 			},
 			expect: true,


### PR DESCRIPTION
Fixes the potential for a false positive unit test in `pkg/operator/controller/controller_service_monitor_test.go`.
Also adds the `kube-rbac-proxy` name to the DNS daemonset config changed function, as well as corresponding unit test.