### PR TITLE
NE-169: Add simple CoreDNS Prometheus alert rules

### DIFF
--- a/manifests/0000_90_dns-operator_03_prometheusrules.yaml
+++ b/manifests/0000_90_dns-operator_03_prometheusrules.yaml
@@ -1,0 +1,24 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: dns
+  namespace: openshift-dns-operator
+  labels:
+    role: alert-rules
+spec:
+  groups:
+    - name: openshift-dns.rules
+      rules:
+      - alert: CoreDNSPanicking
+        expr: coredns_panic_count_total > 0
+        labels:
+          severity: warning
+        annotations:
+          message: "{{ $value }} CoreDNS panics observed on {{ $labels.instance }}"
+      - alert: CoreDNSHealthCheckSlow
+        expr: histogram_quantile(.95, sum(rate(coredns_health_request_duration_seconds_bucket[5m])) by (instance, le)) > 10
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          message: "CoreDNS Health Checks are slowing down (instance {{ $labels.instance }})"


### PR DESCRIPTION
Adds a couple of CoreDNS alert rules.

Still deciding if using the CVO is the best way to apply the `PrometheusRule` object. For now I think it is. If anyone has any input for CVO vs ~OLM~ using the DNS operator for managing DNS alert rules, please feel free to chime in. 

- CoreDNSPanicCount
Triggers if CoreDNS panics
- CoreDNSHealthCheckSlow
Triggers if CoreDNS health checks are significantly slowing down