### PR TITLE
Bug 1838266: Updates Progressing status condition message

### DIFF
--- a/pkg/operator/controller/status.go
+++ b/pkg/operator/controller/status.go
@@ -269,7 +269,7 @@ func (r *reconciler) computeOperatorProgressingCondition(oldCondition *configv1.
 		progressing = true
 	}
 	if dnses.progressing > 0 {
-		messages = append(messages, "Not all DNS DaemonSets available.")
+		messages = append(messages, "At least 1 DNS DaemonSet is progressing.")
 		progressing = true
 	}
 


### PR DESCRIPTION
The DNS operator `Progressing` status condition message should reflect a "progressing", not an "available" message.