### PR TITLE
Bug 1842741: Fix serviceChanged and daemonsetConfigChanged

### DIFF
--- a/pkg/operator/controller/controller_dns_daemonset.go
+++ b/pkg/operator/controller/controller_dns_daemonset.go
@@ -207,7 +207,7 @@ func daemonsetConfigChanged(current, expected *appsv1.DaemonSet) (bool, *appsv1.
 		updated.Spec.Template.Spec.Tolerations = expected.Spec.Template.Spec.Tolerations
 		changed = true
 	}
-	if !cmp.Equal(current.Spec.Template.Spec.Volumes, expected.Spec.Template.Spec.Volumes, cmpopts.EquateEmpty()) {
+	if !cmp.Equal(current.Spec.Template.Spec.Volumes, expected.Spec.Template.Spec.Volumes, cmpopts.EquateEmpty(), cmp.Comparer(cmpConfigMapVolumeSource), cmp.Comparer(cmpSecretVolumeSource)) {
 		updated.Spec.Template.Spec.Volumes = expected.Spec.Template.Spec.Volumes
 		changed = true
 	}
@@ -231,6 +231,62 @@ func daemonsetConfigChanged(current, expected *appsv1.DaemonSet) (bool, *appsv1.
 		return false, nil
 	}
 	return true, updated
+}
+
+// volumeDefaultMode is the default mode value that the API uses for configmap
+// and secret volume sources.  Decimal 420 is octal 0644, which is u=rw,g=r,o=r.
+const volumeDefaultMode = int32(420)
+
+// cmpConfigMapVolumeSource compares two configmap volume source values and
+// returns a Boolean indicating whether they are equal.
+func cmpConfigMapVolumeSource(a, b corev1.ConfigMapVolumeSource) bool {
+	if a.LocalObjectReference != b.LocalObjectReference {
+		return false
+	}
+	if !cmp.Equal(a.Items, b.Items, cmpopts.EquateEmpty()) {
+		return false
+	}
+	aDefaultMode := volumeDefaultMode
+	if a.DefaultMode != nil {
+		aDefaultMode = *a.DefaultMode
+	}
+	bDefaultMode := volumeDefaultMode
+	if b.DefaultMode != nil {
+		bDefaultMode = *b.DefaultMode
+	}
+	if aDefaultMode != bDefaultMode {
+		return false
+	}
+	if !cmp.Equal(a.Optional, b.Optional, cmpopts.EquateEmpty()) {
+		return false
+	}
+	return true
+}
+
+// cmpSecretVolumeSource compares two secret volume source values and returns a
+// Boolean indicating whether they are equal.
+func cmpSecretVolumeSource(a, b corev1.SecretVolumeSource) bool {
+	if a.SecretName != b.SecretName {
+		return false
+	}
+	if !cmp.Equal(a.Items, b.Items, cmpopts.EquateEmpty()) {
+		return false
+	}
+	aDefaultMode := volumeDefaultMode
+	if a.DefaultMode != nil {
+		aDefaultMode = *a.DefaultMode
+	}
+	bDefaultMode := volumeDefaultMode
+	if b.DefaultMode != nil {
+		bDefaultMode = *b.DefaultMode
+	}
+	if aDefaultMode != bDefaultMode {
+		return false
+	}
+	if !cmp.Equal(a.Optional, b.Optional, cmpopts.EquateEmpty()) {
+		return false
+	}
+	return true
 }
 
 // cmpTolerations compares two Tolerations values and returns a Boolean

--- a/pkg/operator/controller/controller_dns_service.go
+++ b/pkg/operator/controller/controller_dns_service.go
@@ -98,6 +98,8 @@ func serviceChanged(current, expected *corev1.Service) (bool, *corev1.Service) {
 		//
 		// TODO: Remove TopologyKeys when the service topology feature gate is enabled.
 		cmpopts.IgnoreFields(corev1.ServiceSpec{}, "ClusterIP", "TopologyKeys"),
+		cmp.Comparer(cmpServiceAffinity),
+		cmp.Comparer(cmpServiceType),
 		cmpopts.EquateEmpty(),
 	}
 
@@ -119,4 +121,24 @@ func serviceChanged(current, expected *corev1.Service) (bool, *corev1.Service) {
 	updated.Spec.ClusterIP = current.Spec.ClusterIP
 
 	return true, updated
+}
+
+func cmpServiceAffinity(a, b corev1.ServiceAffinity) bool {
+	if len(a) == 0 {
+		a = corev1.ServiceAffinityNone
+	}
+	if len(b) == 0 {
+		b = corev1.ServiceAffinityNone
+	}
+	return a == b
+}
+
+func cmpServiceType(a, b corev1.ServiceType) bool {
+	if len(a) == 0 {
+		a = corev1.ServiceTypeClusterIP
+	}
+	if len(b) == 0 {
+		b = corev1.ServiceTypeClusterIP
+	}
+	return a == b
 }

--- a/pkg/operator/controller/controller_dns_service_test.go
+++ b/pkg/operator/controller/controller_dns_service_test.go
@@ -42,6 +42,13 @@ func TestDNSServiceChanged(t *testing.T) {
 			expect: true,
 		},
 		{
+			description: "if .spec.type is defaulted",
+			mutate: func(service *corev1.Service) {
+				service.Spec.Type = corev1.ServiceTypeClusterIP
+			},
+			expect: false,
+		},
+		{
 			description: "if .spec.type changes",
 			mutate: func(service *corev1.Service) {
 				service.Spec.Type = corev1.ServiceTypeNodePort
@@ -49,7 +56,14 @@ func TestDNSServiceChanged(t *testing.T) {
 			expect: true,
 		},
 		{
-			description: "if .spec.sessionAffinity changes",
+			description: "if .spec.sessionAffinity is defaulted",
+			mutate: func(service *corev1.Service) {
+				service.Spec.SessionAffinity = corev1.ServiceAffinityNone
+			},
+			expect: false,
+		},
+		{
+			description: "if .spec.sessionAffinity is set to a non-default value",
 			mutate: func(service *corev1.Service) {
 				service.Spec.SessionAffinity = corev1.ServiceAffinityClientIP
 			},
@@ -96,10 +110,7 @@ func TestDNSServiceChanged(t *testing.T) {
 				Namespace: "openshift-dns",
 				UID:       "1",
 			},
-			Spec: corev1.ServiceSpec{
-				Type:            corev1.ServiceTypeClusterIP,
-				SessionAffinity: corev1.ServiceAffinityNone,
-			},
+			Spec: corev1.ServiceSpec{},
 		}
 		mutated := original.DeepCopy()
 		tc.mutate(mutated)


### PR DESCRIPTION
#### `serviceChanged`: Fix session affinity, type

When comparing services to determine whether an update is required, treat implicit and explicit default values as equal.

Before this commit, the update logic would keep trying to revert the default value that the API set for the service's session affinity or type.

* `pkg/operator/controller/controller_dns_service.go` (`serviceChanged`): Use the new `cmpServiceAffinity` and `cmpServiceType` functions so that two services are considered equal if the only difference between them is that one does not specify the session affinity or type and the other service has the default values.
(`cmpServiceAffinity`, `cmpServiceType`): New function.
* `pkg/operator/controller/controller_dns_service_test.go`: (`TestDNSServiceChanged`): Verify that `serviceChanged` returns false if the only mutation is that the session affinity or type has been updated from empty to the default value.


#### `daemonsetConfigChanged`: Fix for volume default mode

When comparing daemonsets to determine whether an update is required, treat implicit and explicit default values as equal.

Before this commit, the update logic would keep trying to revert the default value that the API set for a volume's default mode.

* `pkg/operator/controller/controller_dns_daemonset.go` (`daemonsetConfigChanged`): Use the new `cmpConfigMapVolumeSource` and `cmpSecretVolumeSource` functions so that two daemonsets are considered equal if the only difference between them is that one does not specify a default mode value and the other daemonset specifies the default value.
(`volumeDefaultMode`): New constant with the default mode that the API uses for configmap and secret volume sources.
(`cmpConfigMapVolumeSource`, `cmpSecretVolumeSource`): New functions.
* `pkg/operator/controller/controller_dns_daemonset_test.go`: (`TestDaemonsetConfigChanged`): Verify that `daemonsetConfigChanged` returns false if the only mutation is that a volume's default mode value has been updated from empty to the default value.