### PR TITLE
DNS Daemonset: Add unit test

### DIFF
--- a/pkg/operator/controller/controller_dns_daemonset_test.go
+++ b/pkg/operator/controller/controller_dns_daemonset_test.go
@@ -155,6 +155,17 @@ func TestDaemonsetConfigChanged(t *testing.T) {
 			},
 			expect: true,
 		},
+		{
+			description: "if an unexpected additional container is added",
+			mutate: func(daemonset *appsv1.DaemonSet) {
+				containers := daemonset.Spec.Template.Spec.Containers
+				daemonset.Spec.Template.Spec.Containers = append(containers, corev1.Container{
+					Name:  "foo",
+					Image: "bar",
+				})
+			},
+			expect: true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Adds a unit test to the DNS daemonset test to cover https://github.com/openshift/cluster-dns-operator/blob/master/pkg/operator/controller/controller_dns_daemonset.go#L213. Adding a new container to the daemonset is something that has recently occurred (#163), so this test would be helpful. 