### PR TITLE
Bug 1813062: ensures service IP is allocatable

### DIFF
--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -364,6 +364,9 @@ func (r *reconciler) ensureDNS(dns *operatorv1.DNS) error {
 			errs = append(errs, fmt.Errorf("failed to create configmap for dns %s: %v", dns.Name, err))
 		}
 		if haveSvc, svc, err := r.ensureDNSService(dns, clusterIP, daemonsetRef); err != nil {
+			// Set clusterIP to an empty string to cause ClusterOperator to report
+			// Available=False and Degraded=True.
+			clusterIP = ""
 			errs = append(errs, fmt.Errorf("failed to create service for dns %s: %v", dns.Name, err))
 		} else if !haveSvc {
 			errs = append(errs, fmt.Errorf("failed to get service for dns %s", dns.Name))


### PR DESCRIPTION
`pkg/operator/controller/controller.go`: Adds `ensureServiceIP()` to ensure the DNS service IP is available for allocation before assigning it to `spec.ClusterIP`.

/assign @Miciah @knobunc 