### PR TITLE
Port coredns errors alert

### DIFF
--- a/manifests/0000_90_dns-operator_03_prometheusrules.yaml
+++ b/manifests/0000_90_dns-operator_03_prometheusrules.yaml
@@ -23,3 +23,14 @@ spec:
           severity: warning
         annotations:
           message: "CoreDNS Health Checks are slowing down (instance {{ $labels.instance }})"
+      - alert: CoreDNSErrorsHigh
+        expr: |
+          (sum(rate(coredns_dns_response_rcode_count_total{rcode="SERVFAIL"}[5m]))
+            /
+          sum(rate(coredns_dns_response_rcode_count_total[5m])))
+          > 0.01
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          message: "CoreDNS is returning SERVFAIL for {{ $value | humanizePercentage }} of requests."

--- a/manifests/0000_90_dns-operator_03_prometheusrules.yaml
+++ b/manifests/0000_90_dns-operator_03_prometheusrules.yaml
@@ -10,7 +10,8 @@ spec:
     - name: openshift-dns.rules
       rules:
       - alert: CoreDNSPanicking
-        expr: coredns_panic_count_total > 0
+        expr: increase(coredns_panic_count_total[10m]) > 0
+        for: 5m
         labels:
           severity: warning
         annotations:


### PR DESCRIPTION
This pr updates the existing `CoreDNSPanicking` metric and add alerts for `CoreDNSErrorsHigh`. For more context, please check https://coreos.slack.com/archives/CCH60A77E/p1595256269123600