### PR TITLE
Bug 1860142: Adds Prometheus rule for forwarding healthcheck metrics

### DIFF
--- a/manifests/0000_90_dns-operator_03_prometheusrules.yaml
+++ b/manifests/0000_90_dns-operator_03_prometheusrules.yaml
@@ -34,3 +34,17 @@ spec:
           severity: warning
         annotations:
           message: "CoreDNS is returning SERVFAIL for {{ $value | humanizePercentage }} of requests."
+      - alert: CoreDNSForwardHealthcheckFailureCount
+        expr: rate(coredns_forward_healthcheck_failure_count_total[10s]) > 3
+        for: 30s
+        labels:
+          severity: warning
+        annotations:
+          message: '{{ $value }} CoreDNS health checks are failing to upstream server {{ $labels.to }} on {{ $labels.instance }}'
+      - alert: CoreDNSForwardHealthcheckBrokenCount
+        expr: rate(coredns_forward_healthcheck_broken_count_total[5s]) > 3
+        for: 15s
+        labels:
+          severity: warning
+        annotations:
+          message: '{{ $value }} CoreDNS health checks are failing for all upstream servers on {{ $labels.instance }}'


### PR DESCRIPTION
This PR adds Prometheus rules for CoreDNS forward plugin health checking metrics. Note that metric `coredns_forward_healthcheck_broken_count_total` requires https://github.com/coredns/coredns/pull/4021 to get ported to [openshift/coredns](https://github.com/openshift/coredns).

Partially fixes [BZ 1860142](https://bugzilla.redhat.com/show_bug.cgi?id=1860142)

/assign @knobunc @miabbott 
/cc @sgreene570 @nstielau @miheer 