### PR TITLE
Bug 1882323: Fix operator namespace in clusteroperator related resources

### DIFF
--- a/pkg/operator/controller/status/controller.go
+++ b/pkg/operator/controller/status/controller.go
@@ -104,7 +104,7 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	related := []configv1.ObjectReference{
 		{
 			Resource: "namespaces",
-			Name:     operatorcontroller.DNSClusterOperatorName().Name,
+			Name:     r.Config.OperatorNamespace,
 		},
 		{
 			Group:    operatorv1.GroupName,


### PR DESCRIPTION
The dns cluster operator is fed the DNS operator's namespace in pkg/operator/controller/status/controller.go. This commit fixes a regression brought in by https://github.com/openshift/cluster-dns-operator/pull/187 in which the cluster operator is given a reference to the "dns" namespace, which does not exist. This commit instead gives the cluster operator a reference to the correct operator namespace set at run time.

--- 

This regression affects must-gather, but could also have potentially unknown consequences since the cluster operator resource is pointing to a nil namespace.