### PR TITLE
Add a field to configure the cache parameter from Corefile

### DIFF
--- a/manifests/0000_70_dns-operator_00-custom-resource-definition.yaml
+++ b/manifests/0000_70_dns-operator_00-custom-resource-definition.yaml
@@ -38,6 +38,13 @@ spec:
           description: spec is the specification of the desired behavior of the DNS.
           type: object
           properties:
+            globalCache:
+                description: "globalCache is an int32 that defines the maximum cache
+                  TTL in seconds. \n All records except zone transfers and metadata
+                  records will be cached. \n If this field is nil, the default 30
+                  seconds will be used."
+                type: integer
+                format: int32
             servers:
               description: "servers is a list of DNS resolvers that provide name query
                 delegation for one or more subdomains outside the scope of the cluster

--- a/pkg/operator/controller/controller_dns_configmap_test.go
+++ b/pkg/operator/controller/controller_dns_configmap_test.go
@@ -15,6 +15,7 @@ func TestDesiredDNSConfigmap(t *testing.T) {
 			Name: DefaultDNSController,
 		},
 		Spec: operatorv1.DNSSpec{
+			GlobalCache: 900,
 			Servers: []operatorv1.Server{
 				{
 					Name:  "foo",
@@ -53,7 +54,7 @@ bar.com:5353 example.com:5353 {
     forward . /etc/resolv.conf {
         policy sequential
     }
-    cache 30
+    cache 900
     reload
 }
 `

--- a/vendor/github.com/openshift/api/operator/v1/0000_70_dns-operator_00-custom-resource-definition.yaml
+++ b/vendor/github.com/openshift/api/operator/v1/0000_70_dns-operator_00-custom-resource-definition.yaml
@@ -38,6 +38,13 @@ spec:
           description: spec is the specification of the desired behavior of the DNS.
           type: object
           properties:
+            globalCache:
+                description: "globalCache is an int32 that defines the maximum cache
+                  TTL in seconds. \n All records except zone transfers and metadata
+                  records will be cached. \n If this field is nil, the default 30
+                  seconds will be used."
+                type: integer
+                format: int32
             servers:
               description: "servers is a list of DNS resolvers that provide name query
                 delegation for one or more subdomains outside the scope of the cluster

--- a/vendor/github.com/openshift/api/operator/v1/types_dns.go
+++ b/vendor/github.com/openshift/api/operator/v1/types_dns.go
@@ -42,6 +42,13 @@ type DNSSpec struct {
 	//
 	// +optional
 	Servers []Server `json:"servers,omitempty"`
+	// globalCache is an int32 that defines the maximum cache TTL in seconds.
+	// All records except zone transfers and metadata records will be cached.
+	//
+	// If this field is nil, the default 30 seconds will be used.
+	//
+	// +optional
+	GlobalCache uint32 `json:"globalCache,omitempty"`
 }
 
 // Server defines the schema for a server that runs per instance of CoreDNS.


### PR DESCRIPTION
Creates a new field called `globalCache` to the DNSSpec from DNS type.
This field is used to define the value of `cache` from the corefileTemplate.