### PR TITLE
WIP: status: Verify and report endpoints availability

### DIFF
--- a/pkg/operator/controller/dns_status.go
+++ b/pkg/operator/controller/dns_status.go
@@ -2,7 +2,12 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -11,16 +16,19 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 // syncDNSStatus computes the current status of dns and
 // updates status upon any changes since last sync.
-func (r *reconciler) syncDNSStatus(dns *operatorv1.DNS, clusterIP, clusterDomain string, ds *appsv1.DaemonSet) error {
+func (r *reconciler) syncDNSStatus(dns *operatorv1.DNS, clusterIP, clusterDomain string, ds *appsv1.DaemonSet, endpoints *corev1.Endpoints) error {
+	resolverErrors := checkEndpoints(ds, endpoints)
 	updated := dns.DeepCopy()
 	updated.Status.ClusterIP = clusterIP
 	updated.Status.ClusterDomain = clusterDomain
-	updated.Status.Conditions = computeDNSStatusConditions(dns.Status.Conditions, clusterIP, ds)
+	updated.Status.Conditions = computeDNSStatusConditions(dns.Status.Conditions, clusterIP, ds, resolverErrors)
 	if !dnsStatusesEqual(updated.Status, dns.Status) {
 		if err := r.client.Status().Update(context.TODO(), updated); err != nil {
 			return fmt.Errorf("failed to update dns status: %v", err)
@@ -31,10 +39,50 @@ func (r *reconciler) syncDNSStatus(dns *operatorv1.DNS, clusterIP, clusterDomain
 	return nil
 }
 
-// computeDNSStatusConditions computes dns status conditions based on
-// the status of ds and clusterIP.
-func computeDNSStatusConditions(oldConditions []operatorv1.OperatorCondition, clusterIP string,
-	ds *appsv1.DaemonSet) []operatorv1.OperatorCondition {
+// checkEndpoints verifies that the provided endpoints by sending a DNS query
+// for the API service host name to each endpoint and returns a list of errors.
+func checkEndpoints(ds *appsv1.DaemonSet, endpoints *corev1.Endpoints) []error {
+	const apiHost = "kubernetes.default.svc.cluster.local."
+	var (
+		errs      []error
+		addresses []string
+	)
+	for _, ep := range endpoints.Subsets {
+		for _, subset := range ep.Addresses {
+			for _, port := range ep.Ports {
+				if port.Protocol != corev1.ProtocolUDP {
+					continue
+				}
+				a, p := subset.IP, strconv.Itoa(int(port.Port))
+				addrPort := net.JoinHostPort(a, p)
+				addresses = append(addresses, addrPort)
+			}
+		}
+	}
+	if len(addresses) < int(ds.Status.NumberAvailable) {
+		errs = append(errs, fmt.Errorf("DaemonSet reports %d pods, but Endpoints has only %d addresses", ds.Status.NumberAvailable, len(addresses)))
+	}
+	// TODO: Parallelize queries.
+	for _, address := range addresses {
+		resolver := &net.Resolver{
+			PreferGo: true,
+			Dial: func(ctx context.Context, network_, address_ string) (net.Conn, error) {
+				dialer := net.Dialer{
+					Timeout: time.Millisecond * 500,
+				}
+				return dialer.DialContext(ctx, "udp", address)
+			},
+		}
+		if _, err := resolver.LookupHost(context.Background(), apiHost); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errs
+}
+
+// computeDNSStatusConditions computes dns status conditions based on the status
+// of ds and clusterIP and any provided resolver errors.
+func computeDNSStatusConditions(oldConditions []operatorv1.OperatorCondition, clusterIP string, ds *appsv1.DaemonSet, resolverErrors []error) []operatorv1.OperatorCondition {
 	var oldDegradedCondition, oldProgressingCondition, oldAvailableCondition *operatorv1.OperatorCondition
 	for i := range oldConditions {
 		switch oldConditions[i].Type {
@@ -48,7 +96,7 @@ func computeDNSStatusConditions(oldConditions []operatorv1.OperatorCondition, cl
 	}
 
 	conditions := []operatorv1.OperatorCondition{
-		computeDNSDegradedCondition(oldDegradedCondition, clusterIP, ds),
+		computeDNSDegradedCondition(oldDegradedCondition, clusterIP, ds, resolverErrors),
 		computeDNSProgressingCondition(oldProgressingCondition, clusterIP, ds),
 		computeDNSAvailableCondition(oldAvailableCondition, clusterIP, ds),
 	}
@@ -57,35 +105,43 @@ func computeDNSStatusConditions(oldConditions []operatorv1.OperatorCondition, cl
 }
 
 // computeDNSDegradedCondition computes the dns Degraded status condition
-// based on the status of clusterIP and ds.
-func computeDNSDegradedCondition(oldCondition *operatorv1.OperatorCondition, clusterIP string,
-	ds *appsv1.DaemonSet) operatorv1.OperatorCondition {
-	degradedCondition := &operatorv1.OperatorCondition{
-		Type: operatorv1.OperatorStatusTypeDegraded,
+// based on the status of clusterIP and ds and any provided resolver errors.
+func computeDNSDegradedCondition(oldCondition *operatorv1.OperatorCondition, clusterIP string, ds *appsv1.DaemonSet, resolverErrors []error) operatorv1.OperatorCondition {
+	var (
+		degradedCondition = &operatorv1.OperatorCondition{
+			Type:   operatorv1.OperatorStatusTypeDegraded,
+			Status: operatorv1.ConditionUnknown,
+		}
+		reasons []string
+		errs    []error
+	)
+
+	if len(resolverErrors) != 0 {
+		reasons = append(reasons, "EndpointsUnavailable")
+		errs = append(errs, resolverErrors...)
 	}
+
 	numberUnavailable := ds.Status.DesiredNumberScheduled - ds.Status.NumberAvailable
-	switch {
-	case len(clusterIP) == 0 && ds.Status.NumberAvailable == 0:
+	if len(clusterIP) == 0 {
+		reasons = append(reasons, "NoServiceIP")
+		errs = append(errs, errors.New("No IP assigned to DNS service"))
+	}
+	if ds.Status.DesiredNumberScheduled == 0 {
+		reasons = append(reasons, "NoPodsDesired")
+		errs = append(errs, errors.New("No CoreDNS pods are scheduled"))
+	} else if ds.Status.NumberAvailable == 0 {
+		reasons = append(reasons, "NoPodsAvailable")
+		errs = append(errs, errors.New("No CoreDNS pods are available"))
+	} else if numberUnavailable > ds.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable.IntVal {
+		reasons = append(reasons, "MaxUnavailableExceeded")
+		errs = append(errs, fmt.Errorf("Too many unavailable CoreDNS pods (%d > %d max unavailable)", numberUnavailable, ds.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable.IntVal))
+	}
+
+	if len(errs) != 0 {
 		degradedCondition.Status = operatorv1.ConditionTrue
-		degradedCondition.Reason = "NoServiceIPAndNoDaemonSetPods"
-		degradedCondition.Message = "No IP assigned to DNS service and no DaemonSet pods running"
-	case len(clusterIP) == 0:
-		degradedCondition.Status = operatorv1.ConditionTrue
-		degradedCondition.Reason = "NoServiceIP"
-		degradedCondition.Message = "No IP assigned to DNS service"
-	case ds.Status.DesiredNumberScheduled == 0:
-		degradedCondition.Status = operatorv1.ConditionTrue
-		degradedCondition.Reason = "NoPodsDesired"
-		degradedCondition.Message = "No CoreDNS pods are desired (this could mean nodes are tainted)"
-	case ds.Status.NumberAvailable == 0:
-		degradedCondition.Status = operatorv1.ConditionTrue
-		degradedCondition.Reason = "NoPodsAvailable"
-		degradedCondition.Message = "No CoreDNS pods are available"
-	case numberUnavailable > ds.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable.IntVal:
-		degradedCondition.Status = operatorv1.ConditionTrue
-		degradedCondition.Reason = "MaxUnavailableExceeded"
-		degradedCondition.Message = fmt.Sprintf("Too many unavailable CoreDNS pods (%d > %d max unavailable)", numberUnavailable, ds.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable.IntVal)
-	default:
+		degradedCondition.Reason = strings.Join(reasons, "And")
+		degradedCondition.Message = utilerrors.NewAggregate(errs).Error()
+	} else {
 		degradedCondition.Status = operatorv1.ConditionFalse
 		degradedCondition.Reason = "AsExpected"
 		degradedCondition.Message = "IP assigned to DNS service and minimum DaemonSet pods running"


### PR DESCRIPTION
* `pkg/operator/controller/controller.go` (`ensureDNS`): Get the DNS service's endpoints and pass it to `syncDNSStatus`.
* `pkg/operator/controller/dns_status.go` (`syncDNSStatus`): Add `endpoints` parameter.  Use endpoints and the new `checkEndpoints` function to verify endpoints, and pass the results to `computeDNSStatusConditions`.
(`checkEndpoints`): New function.  Verify the provided endpoints by sending a DNS query for the API service to each endpoint, and return a list of errors.
(`computeDNSStatusConditions`): Add parameter for resolver errors.  Pass the errors to `computeDNSDegradedCondition`.
(`computeDNSDegradedCondition`): Add parameter for resolver errors.  Report `Degraded=True` if the list of resolver errors is nonempty,
* `pkg/operator/controller/dns_status_test.go` (`TestDNSStatusConditions`): Add test case for resolver errors.