### PR TITLE
WIP: Delete node resolver daemonset if it exists

### DIFF
--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -341,7 +341,8 @@ func (r *reconciler) ensureDNS(dns *operatorv1.DNS) error {
 	// it.  We want to delete the node resolver daemonset before updating
 	// the DNS daemonset to avoid having both the node resolver running in
 	// both daemonsets at the same time.
-	if _, _, err := r.ensureNodeResolverDaemonSet(clusterIP, clusterDomain); err != nil {
+	haveResolverDaemonset, resolverDaemonset, err := r.ensureNodeResolverDaemonSet(dns, clusterIP, clusterDomain)
+	if err != nil {
 		errs = append(errs, err)
 	}
 
@@ -373,7 +374,7 @@ func (r *reconciler) ensureDNS(dns *operatorv1.DNS) error {
 			errs = append(errs, fmt.Errorf("failed to integrate metrics with openshift-monitoring for dns %s: %v", dns.Name, err))
 		}
 
-		if err := r.syncDNSStatus(dns, clusterIP, clusterDomain, daemonset); err != nil {
+		if err := r.syncDNSStatus(dns, clusterIP, clusterDomain, daemonset, haveResolverDaemonset, resolverDaemonset); err != nil {
 			errs = append(errs, fmt.Errorf("failed to sync status of dns %s/%s: %v", daemonset.Namespace, daemonset.Name, err))
 		}
 	}

--- a/pkg/operator/controller/controller_dns_node_resolver_daemonset.go
+++ b/pkg/operator/controller/controller_dns_node_resolver_daemonset.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	operatorv1 "github.com/openshift/api/operator/v1"
+
 	appsv1 "k8s.io/api/apps/v1"
 
 	"github.com/sirupsen/logrus"
@@ -15,10 +17,19 @@ import (
 // should or does not exist if it should not exist.  Returns a Boolean
 // indicating whether the daemonset exists, the daemonset if it does exist, and
 // an error value.
-func (r *reconciler) ensureNodeResolverDaemonSet(clusterIP, clusterDomain string) (bool, *appsv1.DaemonSet, error) {
+func (r *reconciler) ensureNodeResolverDaemonSet(dns *operatorv1.DNS, clusterIP, clusterDomain string) (bool, *appsv1.DaemonSet, error) {
 	haveDS, current, err := r.currentNodeResolverDaemonSet()
 	if err != nil {
 		return false, nil, err
+	}
+	if haveDS {
+		if owns, err := dnsOwnsObject(dns, current); err != nil {
+			return haveDS, current, err
+		} else if !owns {
+			// Return the daemonset without checking if it needs to
+			// be updated because we do not own it.
+			return haveDS, current, nil
+		}
 	}
 	wantDS, _, err := desiredNodeResolverDaemonSet(clusterIP, clusterDomain, r.OpenshiftCLIImage)
 	if err != nil {
@@ -60,5 +71,20 @@ func (r *reconciler) deleteNodeResolverDaemonSet(daemonset *appsv1.DaemonSet) er
 		return fmt.Errorf("failed to delete node resolver daemonset %s/%s: %v", daemonset.Namespace, daemonset.Name, err)
 	}
 	logrus.Infof("deleted node resolver daemonset: %s/%s", daemonset.Namespace, daemonset.Name)
+	return nil
+}
+
+// verifyNodeResolverDaemonIsUpgradeable returns an error value indicating if
+// the node resolver daemonset is safe to upgrade.  In particular, if the
+// daemonset exists but is not labeled as owned by the dns, then the daemonset
+// is not upgradeable, and an error is returned.  Otherwise, nil is returned.
+func verifyNodeResolverDaemonIsUpgradeable(dns *operatorv1.DNS, ds *appsv1.DaemonSet) error {
+	owns, err := dnsOwnsObject(dns, ds)
+	if err != nil {
+		return err
+	}
+	if !owns {
+		return fmt.Errorf("daemonset %s/%s exists but is not owned by dns %s", ds.Namespace, ds.Name, dns.Name)
+	}
 	return nil
 }

--- a/pkg/operator/controller/controller_dns_node_resolver_daemonset.go
+++ b/pkg/operator/controller/controller_dns_node_resolver_daemonset.go
@@ -1,0 +1,64 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+)
+
+// ensureNodeResolverDaemonset ensures the node resolver daemonset exists if it
+// should or does not exist if it should not exist.  Returns a Boolean
+// indicating whether the daemonset exists, the daemonset if it does exist, and
+// an error value.
+func (r *reconciler) ensureNodeResolverDaemonSet(clusterIP, clusterDomain string) (bool, *appsv1.DaemonSet, error) {
+	haveDS, current, err := r.currentNodeResolverDaemonSet()
+	if err != nil {
+		return false, nil, err
+	}
+	wantDS, _, err := desiredNodeResolverDaemonSet(clusterIP, clusterDomain, r.OpenshiftCLIImage)
+	if err != nil {
+		return haveDS, current, fmt.Errorf("failed to build node resolver daemonset: %v", err)
+	}
+	switch {
+	case !wantDS && haveDS:
+		if err := r.deleteNodeResolverDaemonSet(current); err != nil {
+			return true, current, err
+		}
+	}
+	return false, nil, nil
+}
+
+// desiredNodeResolverDaemonSet returns the desired node resolver daemonset.
+func desiredNodeResolverDaemonSet(clusterIP, clusterDomain, openshiftCLIImage string) (bool, *appsv1.DaemonSet, error) {
+	return false, nil, nil
+}
+
+// currentNodeResolverDaemonSet returns the current DNS node resolver
+// daemonset.
+func (r *reconciler) currentNodeResolverDaemonSet() (bool, *appsv1.DaemonSet, error) {
+	daemonset := &appsv1.DaemonSet{}
+	if err := r.client.Get(context.TODO(), NodeResolverDaemonSetName(), daemonset); err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil, nil
+		}
+		return false, nil, err
+	}
+	return true, daemonset, nil
+}
+
+// deleteNodeResolverDaemonSet deletes a DNS node resolver daemonset.
+func (r *reconciler) deleteNodeResolverDaemonSet(daemonset *appsv1.DaemonSet) error {
+	if err := r.client.Delete(context.TODO(), daemonset); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to delete node resolver daemonset %s/%s: %v", daemonset.Namespace, daemonset.Name, err)
+	}
+	logrus.Infof("deleted node resolver daemonset: %s/%s", daemonset.Namespace, daemonset.Name)
+	return nil
+}

--- a/pkg/operator/controller/controller_dns_node_resolver_test.go
+++ b/pkg/operator/controller/controller_dns_node_resolver_test.go
@@ -1,0 +1,17 @@
+package controller
+
+import (
+	"testing"
+)
+
+func TestDesiredNodeResolverDaemonset(t *testing.T) {
+	clusterDomain := "cluster.local"
+	clusterIP := "172.30.77.10"
+	openshiftCLIImage := "openshift/origin-cli:test"
+
+	if want, _, err := desiredNodeResolverDaemonSet(clusterIP, clusterDomain, openshiftCLIImage); err != nil {
+		t.Errorf("invalid node resolver daemonset: %v", err)
+	} else if want {
+		t.Error("expected the node resolver daemonset desired to be false, got true")
+	}
+}

--- a/pkg/operator/controller/names.go
+++ b/pkg/operator/controller/names.go
@@ -12,6 +12,10 @@ const (
 	// daemonset, and the value is the name of the owning dns.
 	controllerDaemonSetLabel = "dns.operator.openshift.io/daemonset-dns"
 
+	// nodeResolverDaemonSetLabelName is the name of the label that
+	// identifies the node resolver daemonset.
+	nodeResolverDaemonSetLabelName = "dns.operator.openshift.io/daemonset-node-resolver"
+
 	// MetricsServingCertAnnotation is the annotation needed to generate
 	// the certificates for secure DNS metrics.
 	MetricsServingCertAnnotation = "service.beta.openshift.io/serving-cert-secret-name"
@@ -92,5 +96,14 @@ func NodeResolverDaemonSetName() types.NamespacedName {
 	return types.NamespacedName{
 		Namespace: DefaultOperandNamespace,
 		Name:      "node-resolver",
+	}
+}
+
+// NodeResolverDaemonSetPodSelector is label selector for node resolver pods.
+func NodeResolverDaemonSetPodSelector() *metav1.LabelSelector {
+	return &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			nodeResolverDaemonSetLabelName: "",
+		},
 	}
 }

--- a/pkg/operator/controller/names.go
+++ b/pkg/operator/controller/names.go
@@ -85,3 +85,12 @@ func DNSServiceMonitorName(dns *operatorv1.DNS) types.NamespacedName {
 func DNSMetricsSecretName(dns *operatorv1.DNS) string {
 	return "dns-" + dns.Name + "-metrics-tls"
 }
+
+// NodeResolverDaemonSetName returns the namespaced name for the node resolver
+// daemonset.
+func NodeResolverDaemonSetName() types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: DefaultOperandNamespace,
+		Name:      "node-resolver",
+	}
+}

--- a/pkg/operator/controller/util.go
+++ b/pkg/operator/controller/util.go
@@ -1,0 +1,22 @@
+package controller
+
+import (
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/cluster-dns-operator/pkg/manifests"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+)
+
+// dnsOwnsObject verifies that the given dns owns the given object.
+func dnsOwnsObject(dns *operatorv1.DNS, object metav1.Object) (bool, error) {
+	key := manifests.OwningDNSLabel
+	val := DNSDaemonSetLabel(dns)
+	req, err := labels.NewRequirement(key, selection.Equals, []string{val})
+	if err != nil {
+		return false, err
+	}
+	sel := labels.NewSelector().Add(*req)
+	return sel.Matches(labels.Set(object.GetLabels())), nil
+}


### PR DESCRIPTION
In OCP 4.7, the node resolver will be split out of the DNS daemonset into a separate daemonset.  If the node resolver daemonset exists on a 4.6 cluster (which could happen during downgrades), it should be deleted to avoid conflicts with the node resolver container in the DNS daemonset.

* `pkg/operator/controller/controller.go` (`ensureDNS`): Call the new `ensureNodeResolverDaemonset` method before calling `ensureDNSDaemonSet` in order to delete any old node resolver daemonset before reconciling the DNS daemonset.
* `pkg/operator/controller/controller_dns_node_resolver_daemonset.go`: New file.
(`ensureNodeResolverDaemonset`): New method.  Check for and delete any existing node resolver daemonset, using the `desiredNodeResolverDaemonSet` function and the `currentNodeResolverDaemonSet` and `deleteNodeResolverDaemonSet` methods.
(`desiredNodeResolverDaemonSet`): New function.  Return `false`.
(`currentNodeResolverDaemonSet`, `deleteNodeResolverDaemonSet`): New methods.
* `pkg/operator/controller/controller_dns_node_resolver_test.go`: New file.
(`TestDesiredNodeResolverDaemonset`): Verify that `desiredNodeResolverDaemonSet` returns `false` and a nil error value.
* `pkg/operator/controller/names.go` (`NodeResolverDaemonSetName`): New function.  Return the name of the node resolver daemonset.