### PR TITLE
Bug 1896923: Configure CoreDNS metrics plugin to use localhost

### DIFF
--- a/cmd/dns-operator/main.go
+++ b/cmd/dns-operator/main.go
@@ -17,7 +17,7 @@ import (
 const operatorNamespace = "openshift-dns-operator"
 
 func main() {
-	metrics.DefaultBindAddress = ":60000"
+	metrics.DefaultBindAddress = "127.0.0.1:60000"
 
 	// Collect operator configuration.
 	releaseVersion := os.Getenv("RELEASE_VERSION")

--- a/pkg/operator/controller/controller_dns_configmap.go
+++ b/pkg/operator/controller/controller_dns_configmap.go
@@ -40,7 +40,7 @@ var corefileTemplate = template.Must(template.New("Corefile").Parse(`{{range .Se
         upstream
         fallthrough in-addr.arpa ip6.arpa
     }
-    prometheus :9153
+    prometheus 127.0.0.1:9153
     forward . /etc/resolv.conf {
         policy sequential
     }

--- a/pkg/operator/controller/controller_dns_configmap_test.go
+++ b/pkg/operator/controller/controller_dns_configmap_test.go
@@ -52,7 +52,7 @@ bar.com:5353 example.com:5353 {
         upstream
         fallthrough in-addr.arpa ip6.arpa
     }
-    prometheus :9153
+    prometheus 127.0.0.1:9153
     forward . /etc/resolv.conf {
         policy sequential
     }


### PR DESCRIPTION
Configure the operator's metrics handler and the CoreDNS metrics plugin to listen on 127.0.0.1 only.

Before this change, metrics were exposed on ports 9153 and 60000, without authentication.  Although the pod spec does not advertise ports 9153 or 60000, the ports were still accessible outside the pod.  After this change, ports 9153 and 60000 are inaccessible outside the pod, so the only way to get metrics is by connecting to port 9154 (for CoreDNS metrics) or port 9393 (for operator metrics) and authenticating with kube-rbac-proxy.

* `cmd/dns-operator/main.go` (`main`): Configure metrics to listen on 127.0.0.1:60000.
* `pkg/operator/controller/controller_dns_configmap.go` (`corefileTemplate`): Configure metrics to listen on 127.0.0.1:9153.
* `pkg/operator/controller/controller_dns_configmap_test.go` (`TestDesiredDNSConfigmap`): Update the expected Corefile accordingly.