### PR TITLE
add 'single-node-production-edge' annotations to CVO manifests.

### DIFF
--- a/manifests/0000_70_dns-operator_00-cluster-role.yaml
+++ b/manifests/0000_70_dns-operator_00-cluster-role.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups:
   - operator.openshift.io

--- a/manifests/0000_70_dns-operator_00-custom-resource-definition.yaml
+++ b/manifests/0000_70_dns-operator_00-custom-resource-definition.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   group: operator.openshift.io
   names:

--- a/manifests/0000_70_dns-operator_00-namespace.yaml
+++ b/manifests/0000_70_dns-operator_00-namespace.yaml
@@ -5,6 +5,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     openshift.io/node-selector: ""
+    include.release.openshift.io/single-node-production-edge: "true"
   name: openshift-dns-operator
   labels:
     # set value to avoid depending on kube admission that depends on openshift apis

--- a/manifests/0000_70_dns-operator_01-cluster-role-binding.yaml
+++ b/manifests/0000_70_dns-operator_01-cluster-role-binding.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 subjects:
 - kind: ServiceAccount
   name: dns-operator

--- a/manifests/0000_70_dns-operator_01-role-binding.yaml
+++ b/manifests/0000_70_dns-operator_01-role-binding.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 subjects:
 - kind: ServiceAccount
   name: dns-operator

--- a/manifests/0000_70_dns-operator_01-role.yaml
+++ b/manifests/0000_70_dns-operator_01-role.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups:
   - ""

--- a/manifests/0000_70_dns-operator_01-service-account.yaml
+++ b/manifests/0000_70_dns-operator_01-service-account.yaml
@@ -8,3 +8,4 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"

--- a/manifests/0000_70_dns-operator_01-service.yaml
+++ b/manifests/0000_70_dns-operator_01-service.yaml
@@ -5,6 +5,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     service.beta.openshift.io/serving-cert-secret-name: metrics-tls
+    include.release.openshift.io/single-node-production-edge: "true"
   labels:
     name: dns-operator
   name: metrics

--- a/manifests/0000_70_dns-operator_02-deployment.yaml
+++ b/manifests/0000_70_dns-operator_02-deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   replicas: 1
   selector:

--- a/manifests/0000_70_dns-operator_03-cluster-operator.yaml
+++ b/manifests/0000_70_dns-operator_03-cluster-operator.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 status:
   versions:
     - name: operator

--- a/manifests/0000_90_dns-operator_00_prometheusrole.yaml
+++ b/manifests/0000_90_dns-operator_00_prometheusrole.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups:
   - ""

--- a/manifests/0000_90_dns-operator_01_prometheusrolebinding.yaml
+++ b/manifests/0000_90_dns-operator_01_prometheusrolebinding.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/manifests/0000_90_dns-operator_02_servicemonitor.yaml
+++ b/manifests/0000_90_dns-operator_02_servicemonitor.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/manifests/0000_90_dns-operator_03_prometheusrules.yaml
+++ b/manifests/0000_90_dns-operator_03_prometheusrules.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   groups:
     - name: openshift-dns.rules


### PR DESCRIPTION
This adds annotations for the single-node-production-edge cluster profile. There's a growing requirement from several customers to enable creation of single-node (not high-available) Openshift clusters.
In stage one (following openshift/enhancements#504) there should be no implication on components logic.
In the next stage, the component's behavior will match a non high-availability profile if the customer is specifically interested in one.
This PR is separate from the 'single-node-developer' work, which will implement a different behavior and is currently on another stage of implementation.

For more info, please refer to the enhancement link and participate in the discussion.