### PR TITLE
NE-514: Corefile: Drop deprecated kubernetes `upstream` option

### DIFF
--- a/pkg/operator/controller/controller_dns_configmap.go
+++ b/pkg/operator/controller/controller_dns_configmap.go
@@ -34,7 +34,6 @@ var corefileTemplate = template.Must(template.New("Corefile").Parse(`{{range .Se
     health
     kubernetes {{.ClusterDomain}} in-addr.arpa ip6.arpa {
         pods insecure
-        upstream
         fallthrough in-addr.arpa ip6.arpa
     }
     prometheus 127.0.0.1:9153

--- a/pkg/operator/controller/controller_dns_configmap_test.go
+++ b/pkg/operator/controller/controller_dns_configmap_test.go
@@ -46,7 +46,6 @@ bar.com:5353 example.com:5353 {
     health
     kubernetes cluster.local in-addr.arpa ip6.arpa {
         pods insecure
-        upstream
         fallthrough in-addr.arpa ip6.arpa
     }
     prometheus 127.0.0.1:9153


### PR DESCRIPTION
https://github.com/coredns/coredns/pull/3737 removed the unused
`upstream` kubernetes plugin option from the CoreDNS corefile parser.
Starting in CoreDNS v1.7, corefiles that have the `upstream` option will
throw an error. This change should not affect functionality since the
`upstream` option has been ignored since CoreDNS v1.5. The
aforementioned upstream CoreDNS PR merely requires that the
`upstream` option be removed for the kubernetes plugin section of a
corefile.

---

This PR will unblock https://github.com/openshift/coredns/pull/52 and is therefore a part of https://issues.redhat.com/browse/NE-514.