### PR TITLE
NE-515: Alerts: Update prometheus alert rules for CoreDNS v1.8.z

### DIFF
--- a/manifests/0000_90_dns-operator_03_prometheusrules.yaml
+++ b/manifests/0000_90_dns-operator_03_prometheusrules.yaml
@@ -13,7 +13,7 @@ spec:
     - name: openshift-dns.rules
       rules:
       - alert: CoreDNSPanicking
-        expr: increase(coredns_panic_count_total[10m]) > 0
+        expr: increase(coredns_panics_total[10m]) > 0
         for: 5m
         labels:
           severity: warning
@@ -28,9 +28,9 @@ spec:
           message: "CoreDNS Health Checks are slowing down (instance {{ $labels.instance }})"
       - alert: CoreDNSErrorsHigh
         expr: |
-          (sum(rate(coredns_dns_response_rcode_count_total{rcode="SERVFAIL"}[5m]))
+          (sum(rate(coredns_dns_responses_total{rcode="SERVFAIL"}[5m]))
             /
-          sum(rate(coredns_dns_response_rcode_count_total[5m])))
+          sum(rate(coredns_dns_responses_total[5m])))
           > 0.01
         for: 5m
         labels:


### PR DESCRIPTION
https://github.com/openshift/coredns/pull/52 updates openshift/coredns to use coredns/coredns v1.8.1. CoreDNS v1.7.0 added breaking metrics renaming changes. This commit changes the following metric names to match the naming used in CoreDNS v1.7.0 and beyond:

* `coredns_dns_response_rcode_count_total` -> `coredns_dns_responses_total`

* `coredns_panic_count_total` -> `coredns_panics_total`

See https://coredns.io/2020/06/15/coredns-1.7.0-release/ for more context.

---

Prerequisites:

- [x] https://github.com/openshift/coredns/pull/52

This PR is in support of https://issues.redhat.com/browse/NE-515