### PR TITLE
Bug 1933761: Set CoreDNS's cache's maximum TTL to 900 seconds

### DIFF
--- a/pkg/operator/controller/controller_dns_configmap.go
+++ b/pkg/operator/controller/controller_dns_configmap.go
@@ -41,7 +41,7 @@ var corefileTemplate = template.Must(template.New("Corefile").Parse(`{{range .Se
     forward . /etc/resolv.conf {
         policy sequential
     }
-    cache 30
+    cache 900
     reload
 }
 `))

--- a/pkg/operator/controller/controller_dns_configmap_test.go
+++ b/pkg/operator/controller/controller_dns_configmap_test.go
@@ -53,7 +53,7 @@ bar.com:5353 example.com:5353 {
     forward . /etc/resolv.conf {
         policy sequential
     }
-    cache 30
+    cache 900
     reload
 }
 `


### PR DESCRIPTION
Before this change, the operator configured CoreDNS's cache plugin with a maximum TTL of 30 seconds, meaning cache entries expired after 30 seconds (or sooner, depending on the TTL from the upstream resolver).  This change increases the maximum TTL to 900 seconds to reduce load on upstream resolvers.

* `pkg/operator/controller/controller_dns_configmap.go` (`corefileTemplate`): Configure the cache plugin with a 900-second maximum TTL.
* `pkg/operator/controller/controller_dns_configmap_test.go` (`TestDesiredDNSConfigmap`): Update to expect the new value.