### PR TITLE
Bug 1934905: Enable errors plugin for custom upstream resolvers

### DIFF
--- a/pkg/operator/controller/controller_dns_configmap.go
+++ b/pkg/operator/controller/controller_dns_configmap.go
@@ -27,6 +27,7 @@ var corefileTemplate = template.Must(template.New("Corefile").Parse(`{{range .Se
     {{with .ForwardPlugin -}}
     forward .{{range .Upstreams}} {{.}}{{end}}
     {{- end}}
+    errors
 }
 {{end -}}
 .:5353 {

--- a/pkg/operator/controller/controller_dns_configmap_test.go
+++ b/pkg/operator/controller/controller_dns_configmap_test.go
@@ -36,10 +36,12 @@ func TestDesiredDNSConfigmap(t *testing.T) {
 	expectedCorefile := `# foo
 foo.com:5353 {
     forward . 1.1.1.1 2.2.2.2:5353
+    errors
 }
 # bar
 bar.com:5353 example.com:5353 {
     forward . 3.3.3.3
+    errors
 }
 .:5353 {
     errors


### PR DESCRIPTION
Before this change, the operator did not enable the "errors" plugin in server blocks for custom upstream resolvers.  As a consequence, failures from upstream resolvers were not logged.  This change enables the errors plugin for all server blocks.

* `pkg/operator/controller/controller_dns_configmap.go` (`corefileTemplate`): Add the errors plugin to server blocks for custom upstream resolvers.
* `pkg/operator/controller/controller_dns_configmap_test.go` (`TestDesiredDNSConfigmap`): Update to expect the errors plugin in all server blocks.