### PR TITLE
Bug 1936022: Fix spurious reconciliation of DNS daemonset and service

### DIFF
--- a/pkg/operator/controller/controller_cluster_role.go
+++ b/pkg/operator/controller/controller_cluster_role.go
@@ -62,10 +62,12 @@ func (r *reconciler) updateDNSClusterRole(current, desired *rbacv1.ClusterRole) 
 		return false, nil
 	}
 
+	// Diff before updating because the client may mutate the object.
+	diff := cmp.Diff(current, updated, cmpopts.EquateEmpty())
 	if err := r.client.Update(context.TODO(), updated); err != nil {
 		return false, fmt.Errorf("failed to update dns cluster role %s/%s: %v", updated.Namespace, updated.Name, err)
 	}
-	logrus.Infof("updated dns cluster role: %s/%s", updated.Namespace, updated.Name)
+	logrus.Infof("updated dns cluster role %s/%s: %v", updated.Namespace, updated.Name, diff)
 	return true, nil
 }
 

--- a/pkg/operator/controller/controller_dns_configmap.go
+++ b/pkg/operator/controller/controller_dns_configmap.go
@@ -127,10 +127,12 @@ func (r *reconciler) updateDNSConfigMap(current, desired *corev1.ConfigMap) (boo
 		return false, nil
 	}
 
+	// Diff before updating because the client may mutate the object.
+	diff := cmp.Diff(current, updated, cmpopts.EquateEmpty())
 	if err := r.client.Update(context.TODO(), updated); err != nil {
 		return false, fmt.Errorf("failed to update configmap: %v", err)
 	}
-	logrus.Infof("updated configmap; old: %#v, new: %#v", current, updated)
+	logrus.Infof("updated configmap %s/%s: %v", updated.Namespace, updated.Name, diff)
 	return true, nil
 }
 

--- a/pkg/operator/controller/controller_dns_daemonset.go
+++ b/pkg/operator/controller/controller_dns_daemonset.go
@@ -257,10 +257,6 @@ func daemonsetConfigChanged(current, expected *appsv1.DaemonSet) (bool, *appsv1.
 	return true, updated
 }
 
-// volumeDefaultMode is the default mode value that the API uses for configmap
-// and secret volume sources.  Decimal 420 is octal 0644, which is u=rw,g=r,o=r.
-const volumeDefaultMode = int32(420)
-
 // cmpConfigMapVolumeSource compares two configmap volume source values and
 // returns a Boolean indicating whether they are equal.
 func cmpConfigMapVolumeSource(a, b corev1.ConfigMapVolumeSource) bool {
@@ -270,11 +266,11 @@ func cmpConfigMapVolumeSource(a, b corev1.ConfigMapVolumeSource) bool {
 	if !cmp.Equal(a.Items, b.Items, cmpopts.EquateEmpty()) {
 		return false
 	}
-	aDefaultMode := volumeDefaultMode
+	aDefaultMode := corev1.ConfigMapVolumeSourceDefaultMode
 	if a.DefaultMode != nil {
 		aDefaultMode = *a.DefaultMode
 	}
-	bDefaultMode := volumeDefaultMode
+	bDefaultMode := corev1.ConfigMapVolumeSourceDefaultMode
 	if b.DefaultMode != nil {
 		bDefaultMode = *b.DefaultMode
 	}
@@ -296,11 +292,11 @@ func cmpSecretVolumeSource(a, b corev1.SecretVolumeSource) bool {
 	if !cmp.Equal(a.Items, b.Items, cmpopts.EquateEmpty()) {
 		return false
 	}
-	aDefaultMode := volumeDefaultMode
+	aDefaultMode := corev1.SecretVolumeSourceDefaultMode
 	if a.DefaultMode != nil {
 		aDefaultMode = *a.DefaultMode
 	}
-	bDefaultMode := volumeDefaultMode
+	bDefaultMode := corev1.SecretVolumeSourceDefaultMode
 	if b.DefaultMode != nil {
 		bDefaultMode = *b.DefaultMode
 	}

--- a/pkg/operator/controller/controller_dns_daemonset.go
+++ b/pkg/operator/controller/controller_dns_daemonset.go
@@ -156,10 +156,12 @@ func (r *reconciler) updateDNSDaemonSet(current, desired *appsv1.DaemonSet) (boo
 		return false, nil
 	}
 
+	// Diff before updating because the client may mutate the object.
+	diff := cmp.Diff(current, updated, cmpopts.EquateEmpty())
 	if err := r.client.Update(context.TODO(), updated); err != nil {
 		return false, fmt.Errorf("failed to update dns daemonset %s/%s: %v", updated.Namespace, updated.Name, err)
 	}
-	logrus.Infof("updated dns daemonset: %s/%s", updated.Namespace, updated.Name)
+	logrus.Infof("updated dns daemonset %s/%s: %v", updated.Namespace, updated.Name, diff)
 	return true, nil
 }
 

--- a/pkg/operator/controller/controller_dns_daemonset.go
+++ b/pkg/operator/controller/controller_dns_daemonset.go
@@ -223,7 +223,7 @@ func daemonsetConfigChanged(current, expected *appsv1.DaemonSet) (bool, *appsv1.
 		updated.Spec.Template.Spec.NodeSelector = expected.Spec.Template.Spec.NodeSelector
 		changed = true
 	}
-	if !cmp.Equal(current.Spec.Template.Spec.TerminationGracePeriodSeconds, expected.Spec.Template.Spec.TerminationGracePeriodSeconds, cmpopts.EquateEmpty()) {
+	if !cmp.Equal(current.Spec.Template.Spec.TerminationGracePeriodSeconds, expected.Spec.Template.Spec.TerminationGracePeriodSeconds, cmpopts.EquateEmpty(), cmp.Comparer(cmpTerminationGracePeriodSeconds)) {
 		updated.Spec.Template.Spec.TerminationGracePeriodSeconds = expected.Spec.Template.Spec.TerminationGracePeriodSeconds
 		changed = true
 	}
@@ -338,4 +338,18 @@ func cmpTolerations(a, b corev1.Toleration) bool {
 		}
 	}
 	return true
+}
+
+// cmpTerminationGracePeriodSeconds compares two terminationGracePeriodSeconds
+// values and returns a Boolean indicating whether they are equal.
+func cmpTerminationGracePeriodSeconds(a, b *int64) bool {
+	aVal := int64(corev1.DefaultTerminationGracePeriodSeconds)
+	if a != nil {
+		aVal = *a
+	}
+	bVal := int64(corev1.DefaultTerminationGracePeriodSeconds)
+	if b != nil {
+		bVal = *b
+	}
+	return aVal == bVal
 }

--- a/pkg/operator/controller/controller_dns_daemonset_test.go
+++ b/pkg/operator/controller/controller_dns_daemonset_test.go
@@ -171,7 +171,7 @@ func TestDaemonsetConfigChanged(t *testing.T) {
 		{
 			description: "if the config-volume default mode value is defaulted",
 			mutate: func(daemonset *appsv1.DaemonSet) {
-				newVal := volumeDefaultMode
+				newVal := corev1.ConfigMapVolumeSourceDefaultMode
 				daemonset.Spec.Template.Spec.Volumes[0].ConfigMap.DefaultMode = &newVal
 			},
 			expect: false,
@@ -187,7 +187,7 @@ func TestDaemonsetConfigChanged(t *testing.T) {
 		{
 			description: "if the metrics-tls default mode value is defaulted",
 			mutate: func(daemonset *appsv1.DaemonSet) {
-				newVal := volumeDefaultMode
+				newVal := corev1.SecretVolumeSourceDefaultMode
 				daemonset.Spec.Template.Spec.Volumes[2].Secret.DefaultMode = &newVal
 			},
 			expect: false,

--- a/pkg/operator/controller/controller_dns_daemonset_test.go
+++ b/pkg/operator/controller/controller_dns_daemonset_test.go
@@ -215,6 +215,14 @@ func TestDaemonsetConfigChanged(t *testing.T) {
 			expect: true,
 		},
 		{
+			description: "if the termination grace period is defaulted",
+			mutate: func(daemonset *appsv1.DaemonSet) {
+				newVal := int64(corev1.DefaultTerminationGracePeriodSeconds)
+				daemonset.Spec.Template.Spec.TerminationGracePeriodSeconds = &newVal
+			},
+			expect: false,
+		},
+		{
 			description: "if the termination grace period changes",
 			mutate: func(daemonset *appsv1.DaemonSet) {
 				sixty := int64(60)

--- a/pkg/operator/controller/controller_dns_service.go
+++ b/pkg/operator/controller/controller_dns_service.go
@@ -99,7 +99,7 @@ func serviceChanged(current, expected *corev1.Service) (bool, *corev1.Service) {
 		// have modified.
 		//
 		// TODO: Remove TopologyKeys when the service topology feature gate is enabled.
-		cmpopts.IgnoreFields(corev1.ServiceSpec{}, "ClusterIP", "TopologyKeys"),
+		cmpopts.IgnoreFields(corev1.ServiceSpec{}, "ClusterIP", "ClusterIPs", "TopologyKeys"),
 		cmp.Comparer(cmpServiceAffinity),
 		cmp.Comparer(cmpServiceType),
 		cmpopts.EquateEmpty(),

--- a/pkg/operator/controller/controller_dns_service.go
+++ b/pkg/operator/controller/controller_dns_service.go
@@ -84,10 +84,12 @@ func (r *reconciler) updateDNSService(current, desired *corev1.Service) (bool, e
 		return false, nil
 	}
 
+	// Diff before updating because the client may mutate the object.
+	diff := cmp.Diff(current, updated, cmpopts.EquateEmpty())
 	if err := r.client.Update(context.TODO(), updated); err != nil {
 		return false, fmt.Errorf("failed to update dns service %s/%s: %v", updated.Namespace, updated.Name, err)
 	}
-	logrus.Infof("updated dns service: %s/%s", updated.Namespace, updated.Name)
+	logrus.Infof("updated dns service %s/%s: %v", updated.Namespace, updated.Name, diff)
 	return true, nil
 }
 

--- a/pkg/operator/controller/controller_dns_service_test.go
+++ b/pkg/operator/controller/controller_dns_service_test.go
@@ -80,6 +80,7 @@ func TestDNSServiceChanged(t *testing.T) {
 			description: "if .spec.clusterIP changes",
 			mutate: func(service *corev1.Service) {
 				service.Spec.ClusterIP = "1.2.3.4"
+				service.Spec.ClusterIPs = []string{"1.2.3.4"}
 			},
 			expect: false,
 		},

--- a/pkg/operator/controller/controller_service_monitor.go
+++ b/pkg/operator/controller/controller_service_monitor.go
@@ -105,10 +105,12 @@ func (r *reconciler) updateDNSServiceMonitor(current, desired *unstructured.Unst
 		return false, nil
 	}
 
+	// Diff before updating because the client may mutate the object.
+	diff := cmp.Diff(current, updated, cmpopts.EquateEmpty())
 	if err := r.client.Update(context.TODO(), updated); err != nil {
 		return false, fmt.Errorf("failed to update dns servicemonitor %s/%s: %v", updated.GetNamespace(), updated.GetName(), err)
 	}
-	logrus.Infof("updated dns servicemonitor: %s/%s", updated.GetNamespace(), updated.GetName())
+	logrus.Infof("updated dns servicemonitor %s/%s: %v", updated.GetNamespace(), updated.GetName(), diff)
 	return true, nil
 }
 


### PR DESCRIPTION
#### Log diffs when reconciling resources

This PR improves log output when reconciling managed resources to log the diff between the current and updated resources when performing an update.

* `pkg/operator/controller/controller_cluster_role.go` (`updateDNSClusterRole`):
* `pkg/operator/controller/controller_dns_daemonset.go` (`updateDNSDaemonSet`):
* `pkg/operator/controller/controller_dns_service.go` (`updateDNSService`):
* `pkg/operator/controller/controller_service_monitor.go` (`updateDNSServiceMonitor`): Log the diff between the current and updated resources when performing an update.


#### `daemonsetConfigChanged`: Fix for `terminationGracePeriodSeconds` defaulting

When comparing daemonsets to determine whether an update is required, treat implicit and explicit default values for `terminationGracePeriodSeconds` as equal.

Before this PR, the update logic would keep trying to revert the default value that the API set for the daemonset's `terminationGracePeriodSeconds` field.

Follow-up to #205, which added the logic which reconciles `terminationGracePeriodSeconds`.

* `pkg/operator/controller/controller_dns_daemonset.go` (`daemonsetConfigChanged`): Use the new `cmpTerminationGracePeriodSeconds` function to compare `terminationGracePeriodSeconds` values so that two daemonsets are considered equal if the only difference between them is that one does not specify `terminationGracePeriodSeconds` and the other daemonset has the default value.
(`cmpTerminationGracePeriodSeconds`): New function.
* `pkg/operator/controller/controller_dns_daemonset_test.go` (`TestDaemonsetConfigChanged`): Verify that `daemonsetConfigChanged` returns false if the only mutation is that `terminationGracePeriodSeconds` has been updated from empty to the default value.


#### `serviceChanged`: Fix for `clusterIPs` defaulting

Ignore the `clusterIPs` field when comparing services to determine whether an update is required.

Before this PR, the update logic would keep trying to revert the value that the API set for the service's `clusterIPs` field.

The `clusterIPs` field is new in Kubernetes 1.20 (OpenShift 4.7).

* `pkg/operator/controller/controller_dns_service.go` (`serviceChanged`): Ignore the services' `clusterIPs` field.
* `pkg/operator/controller/controller_dns_service_test.go` (`TestDNSServiceChanged`): Verify that `serviceChanged` returns false if the only mutation is that the `clusterIPs` field's value has changed.