### PR TITLE
Bug 1943578: Corefile: Use 30 second max TTL for caching of negative responses

### DIFF
--- a/pkg/operator/controller/controller_dns_configmap.go
+++ b/pkg/operator/controller/controller_dns_configmap.go
@@ -44,7 +44,9 @@ var corefileTemplate = template.Must(template.New("Corefile").Parse(`{{range .Se
     forward . /etc/resolv.conf {
         policy sequential
     }
-    cache 900
+    cache 900 {
+        denial 9984 30
+    }
     reload
 }
 `))

--- a/pkg/operator/controller/controller_dns_configmap_test.go
+++ b/pkg/operator/controller/controller_dns_configmap_test.go
@@ -57,7 +57,9 @@ bar.com:5353 example.com:5353 {
     forward . /etc/resolv.conf {
         policy sequential
     }
-    cache 900
+    cache 900 {
+        denial 9984 30
+    }
     reload
 }
 `


### PR DESCRIPTION
Commit 066b3f7 bumped the max TTL for records in the CoreDNS cache to 900 seconds, including negative DNS responses such as NXDOMAIN. This max TTL applies to responses received from the cluster's upstream resolver.

This commit fixes bug 1943578 by lowering the CoreDNS cache max TTL for negative DNS responses to 30 seconds (while maintaining the new 900 second max TTL for positive responses).

Note that `9984` is the default cache size. See https://coredns.io/plugins/cache/ for more context.

This commit resolves https://bugzilla.redhat.com/show_bug.cgi?id=1943578.

pkg/operator/controller/controller_dns_configmap.go:
Configure the cache plugin with a 900 second TTL for positive records and 30 second TTL for negative records in the CoreDNS Corefile.

pkg/operator/controller/controller_dns_configmap_test.go:
Update Corefile unit tests.

