### PR TITLE
node-resolver: Use "kubernetes.io/os" node label

### DIFF
--- a/pkg/operator/controller/controller_dns_node_resolver_daemonset.go
+++ b/pkg/operator/controller/controller_dns_node_resolver_daemonset.go
@@ -136,7 +136,7 @@ func desiredNodeResolverDaemonSet(clusterIP, clusterDomain, openshiftCLIImage st
 					// scarce resource.
 					HostNetwork: true,
 					NodeSelector: map[string]string{
-						"beta.kubernetes.io/os": "linux",
+						"kubernetes.io/os": "linux",
 					},
 					PriorityClassName:  "system-node-critical",
 					ServiceAccountName: "node-resolver",


### PR DESCRIPTION
Replace "beta.kuberneta.io/os" with "kubernetes.io/os" in the node-resolver pods' node selector.  The old label was superseded by the new one and deprecated in Kubernetes 1.14 and subsequently removed in Kubernetes 1.19.

Follow-up to #209.

* `pkg/operator/controller/controller_dns_node_resolver_daemonset.go` (`desiredNodeResolverDaemonSet`): Change node selector from `beta.kubernetes.io/os: linux` to `kubernetes.io/os: linux`.

---

Thanks to @sgreene570 for noticing the old label!