### PR TITLE
status: Watch clusteroperators

### DIFF
--- a/manifests/0000_70_dns-operator_00-cluster-role.yaml
+++ b/manifests/0000_70_dns-operator_00-cluster-role.yaml
@@ -102,6 +102,8 @@ rules:
   verbs:
   - create
   - get
+  - list
+  - watch
 
 - apiGroups:
   - config.openshift.io


### PR DESCRIPTION
Add a watch on clusteroperators in the status controller so that it updates or recreates the dns clusteroperator as necessary should something else update or delete it.

* `pkg/operator/controller/status/controller.go` (`New`): Watch clusteroperators with a map function and predicate to reconcile `dnses.operator.openshift.io/default` if `clusteroperators.config.openshift.io/dns` is updated.
* test/e2e/operator_test.go (TestOperatorRecreatesItsClusterOperator): New test.  Verify that the operator recreates the "dns" clusteroperator if the clusteroperator is deleted.