### PR TITLE
Bug 1949361: Corefile: Enable bufsize plugin for all servers

### DIFF
--- a/pkg/operator/controller/controller_dns_configmap.go
+++ b/pkg/operator/controller/controller_dns_configmap.go
@@ -28,9 +28,11 @@ var corefileTemplate = template.Must(template.New("Corefile").Parse(`{{range .Se
     forward .{{range .Upstreams}} {{.}}{{end}}
     {{- end}}
     errors
+    bufsize 1232
 }
 {{end -}}
 .:5353 {
+    bufsize 1232
     errors
     health {
         lameduck 20s

--- a/pkg/operator/controller/controller_dns_configmap_test.go
+++ b/pkg/operator/controller/controller_dns_configmap_test.go
@@ -37,13 +37,16 @@ func TestDesiredDNSConfigmap(t *testing.T) {
 foo.com:5353 {
     forward . 1.1.1.1 2.2.2.2:5353
     errors
+    bufsize 1232
 }
 # bar
 bar.com:5353 example.com:5353 {
     forward . 3.3.3.3
     errors
+    bufsize 1232
 }
 .:5353 {
+    bufsize 1232
     errors
     health {
         lameduck 20s


### PR DESCRIPTION
Enable the CoreDNS bufsize plugin (https://coredns.io/plugins/bufsize/)
with a buffer size value of `1232` bytes to accomplish the following:

* Limit a requester's UDP payload size.
* Prevent UDP packet fragmentation when DNS responses are >512 bytes.
* Add an EDNS OPT pseudo RR when a client _does not_ specify one.

This commit resolves Bug 1949361, particularly via the 3rd bullet listed
above. When a DNS query bound for an upstream resolver is forwarded without
any EDNS OPT pseudo RR, the upstream resolver may send back packets that
exceed CoreDNS's UDP buffer size, resulting in a SERVFAIL response
(along with various CoreDNS errors being logged).

Note that preventing DNS packet fragmentation may mitigate potential
security vulnerabilities. See https://dnsflagday.net/2020/ for more
information to that end.

pkg/operator/controller/controller_dns_configmap.go:

Add `bufsize 1232` to the CoreDNS configmap template for all servers.

pkg/operator/controller/controller_dns_configmap_test.go:

Update configmap unit tests with proper `bufsize` parameters.