### PR TITLE
Bug 1953280: node-resolver: Set owner reference on the dns

### DIFF
--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -380,7 +380,7 @@ func (r *reconciler) ensureDNS(dns *operatorv1.DNS) error {
 		}
 	}
 
-	haveNodeResolverDaemonset, nodeResolverDaemonset, err := r.ensureNodeResolverDaemonSet(clusterIP, clusterDomain)
+	haveNodeResolverDaemonset, nodeResolverDaemonset, err := r.ensureNodeResolverDaemonSet(dns, clusterIP, clusterDomain)
 	if err != nil {
 		errs = append(errs, err)
 	}

--- a/pkg/operator/controller/controller_dns_node_resolver_daemonset_test.go
+++ b/pkg/operator/controller/controller_dns_node_resolver_daemonset_test.go
@@ -3,6 +3,8 @@ package controller
 import (
 	"testing"
 
+	operatorv1 "github.com/openshift/api/operator/v1"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 
@@ -16,7 +18,13 @@ func TestDesiredNodeResolverDaemonset(t *testing.T) {
 	clusterIP := "172.30.77.10"
 	openshiftCLIImage := "openshift/origin-cli:test"
 
-	if want, ds, err := desiredNodeResolverDaemonSet(clusterIP, clusterDomain, openshiftCLIImage); err != nil {
+	dns := &operatorv1.DNS{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: DefaultDNSController,
+		},
+	}
+
+	if want, ds, err := desiredNodeResolverDaemonSet(dns, clusterIP, clusterDomain, openshiftCLIImage); err != nil {
 		t.Errorf("invalid node resolver daemonset: %v", err)
 	} else if !want {
 		t.Error("expected the node resolver daemonset desired to be true, got false")


### PR DESCRIPTION
Configure the node-resolver daemonset with an owner reference on the dns.

The dns controller watches daemonsets in the operand namespace and enqueues reconcile requests for a daemonset's owner, so without the owner reference, events for the node-resolver daemonset are ignored.

* `pkg/operator/controller/controller.go` (`ensureDNS`): Pass `dns` to `ensureNodeResolverDaemonset`.
* `pkg/operator/controller/controller_dns_node_resolver_daemonset.go` (`ensureNodeResolverDaemonset`): Add `dns` parameter.  Pass `dns` to `desiredNodeResolverDaemonSet`.
(`desiredNodeResolverDaemonSet`): Add `dns` parameter.  Add an owner reference on the dns, so that the controller's watch on daemonsets maps updates to the node-resolver daemonset to reconcile requests for the dns.
* `pkg/operator/controller/controller_dns_node_resolver_daemonset_test.go` (`TestDesiredNodeResolverDaemonset`): Update call to `desiredNodeResolverDaemonSet`.