### PR TITLE
Bug 1966116: Corefile: Set bufsize to 512 bytes for all servers

### DIFF
--- a/pkg/operator/controller/controller_dns_configmap.go
+++ b/pkg/operator/controller/controller_dns_configmap.go
@@ -28,11 +28,11 @@ var corefileTemplate = template.Must(template.New("Corefile").Parse(`{{range .Se
     forward .{{range .Upstreams}} {{.}}{{end}}
     {{- end}}
     errors
-    bufsize 1232
+    bufsize 512
 }
 {{end -}}
 .:5353 {
-    bufsize 1232
+    bufsize 512
     errors
     health {
         lameduck 20s

--- a/pkg/operator/controller/controller_dns_configmap_test.go
+++ b/pkg/operator/controller/controller_dns_configmap_test.go
@@ -37,16 +37,16 @@ func TestDesiredDNSConfigmap(t *testing.T) {
 foo.com:5353 {
     forward . 1.1.1.1 2.2.2.2:5353
     errors
-    bufsize 1232
+    bufsize 512
 }
 # bar
 bar.com:5353 example.com:5353 {
     forward . 3.3.3.3
     errors
-    bufsize 1232
+    bufsize 512
 }
 .:5353 {
-    bufsize 1232
+    bufsize 512
     errors
     health {
         lameduck 20s


### PR DESCRIPTION
The CoreDNS bufsize plugin was enabled with a set size
of 1232 bytes in order to ensure that DNS queries bound for
an upstream resolver contain EDNS OPT Resource Records.
This resolved Bug 1949361.

Some DNS Clients, such as Go's built-in stub DNS resolver, are not
capable of handling DNS UDP messages that are larger than 512 bytes
(even if the proper EDNS flags are included in the message).
See https://github.com/golang/go/issues/13561 &
https://github.com/golang/go/issues/6464 accordingly.

This commit configures the bufsize plugin with a reduced bufsize of 512
bytes for all servers to ensure compatibility with primitive DNS
clients.

pkg/operator/controller/controller_dns_configmap.go:

Set bufsize to 512 bytes for all servers.

pkg/operator/controller/controller_dns_configmap_test.go:

Update unit test cases.

This commit is in support of Bug 196616 and should not cause
any regression from the changes merged as a part of Bug 1949361.