### PR TITLE
Bug 1973482: status: Watch daemonsets

### DIFF
--- a/pkg/operator/controller/status/controller.go
+++ b/pkg/operator/controller/status/controller.go
@@ -75,6 +75,9 @@ func New(mgr manager.Manager, config operatorconfig.Config) (controller.Controll
 	if err := c.Watch(&source.Kind{Type: &operatorv1.DNS{}}, &handler.EnqueueRequestForObject{}); err != nil {
 		return nil, err
 	}
+	if err := c.Watch(&source.Kind{Type: &appsv1.DaemonSet{}}, &handler.EnqueueRequestForOwner{OwnerType: &operatorv1.DNS{}}); err != nil {
+		return nil, err
+	}
 	return c, nil
 }
 


### PR DESCRIPTION
Add a watch on daemonsets to the status controller so that it updates status when the daemonset's spec or status changes.

* `pkg/operator/controller/status/controller.go` (`New`): Watch daemonsets.