### PR TITLE
Bug 2002461: serviceChanged: Fix internalTrafficPolicy

### DIFF
--- a/pkg/operator/controller/controller_dns_service.go
+++ b/pkg/operator/controller/controller_dns_service.go
@@ -107,6 +107,7 @@ func serviceChanged(current, expected *corev1.Service) (bool, *corev1.Service) {
 		),
 		cmp.Comparer(cmpServiceAffinity),
 		cmp.Comparer(cmpServiceType),
+		cmp.Comparer(cmpServiceInternalTrafficPolicyType),
 		cmpopts.EquateEmpty(),
 	}
 
@@ -148,4 +149,15 @@ func cmpServiceType(a, b corev1.ServiceType) bool {
 		b = corev1.ServiceTypeClusterIP
 	}
 	return a == b
+}
+
+func cmpServiceInternalTrafficPolicyType(a, b *corev1.ServiceInternalTrafficPolicyType) bool {
+	defaultPolicy := corev1.ServiceInternalTrafficPolicyCluster
+	if a == nil {
+		a = &defaultPolicy
+	}
+	if b == nil {
+		b = &defaultPolicy
+	}
+	return *a == *b
 }

--- a/pkg/operator/controller/controller_dns_service_test.go
+++ b/pkg/operator/controller/controller_dns_service_test.go
@@ -70,6 +70,22 @@ func TestDNSServiceChanged(t *testing.T) {
 			expect: true,
 		},
 		{
+			description: "if .spec.internalTrafficPolicy is defaulted",
+			mutate: func(service *corev1.Service) {
+				policy := corev1.ServiceInternalTrafficPolicyCluster
+				service.Spec.InternalTrafficPolicy = &policy
+			},
+			expect: false,
+		},
+		{
+			description: "if .spec.internalTrafficPolicy is set to a non-default value",
+			mutate: func(service *corev1.Service) {
+				policy := corev1.ServiceInternalTrafficPolicyLocal
+				service.Spec.InternalTrafficPolicy = &policy
+			},
+			expect: true,
+		},
+		{
 			description: "if .spec.publishNotReadyAddresses changes",
 			mutate: func(service *corev1.Service) {
 				service.Spec.PublishNotReadyAddresses = true


### PR DESCRIPTION
When comparing services to determine whether an update is required, treat the empty value and default value for `spec.internalTrafficPolicy` as equal.

Before this change, the update logic would keep trying to revert the default value that the API set for the service's internal traffic policy.

The `spec.internalTrafficPolicy` field is newly enabled in Kubernetes 1.22 (OpenShift 4.9).

* `pkg/operator/controller/controller_dns_service.go` (`serviceChanged`): Use the new `cmpServiceInternalTrafficPolicyType` function so that two services are considered equal if the only difference between them is that one does not specify internal traffic policy and the other service has the default value.
(`cmpServiceInternalTrafficPolicyType`): New function.
* `pkg/operator/controller/controller_dns_service_test.go` (`TestDNSServiceChanged`): Verify that `serviceChanged` returns false if the only mutation is that the internal traffic policy has been updated from empty to the default value.