### PR TITLE
Bug 2006803: Set CoreDNS cache entries for forwarded zones

### DIFF
--- a/pkg/operator/controller/controller_dns_configmap.go
+++ b/pkg/operator/controller/controller_dns_configmap.go
@@ -29,6 +29,9 @@ var corefileTemplate = template.Must(template.New("Corefile").Parse(`{{range .Se
     {{- end}}
     errors
     bufsize 512
+    cache 900 {
+        denial 9984 30
+    }
 }
 {{end -}}
 .:5353 {

--- a/pkg/operator/controller/controller_dns_configmap_test.go
+++ b/pkg/operator/controller/controller_dns_configmap_test.go
@@ -38,12 +38,18 @@ foo.com:5353 {
     forward . 1.1.1.1 2.2.2.2:5353
     errors
     bufsize 512
+    cache 900 {
+        denial 9984 30
+    }
 }
 # bar
 bar.com:5353 example.com:5353 {
     forward . 3.3.3.3
     errors
     bufsize 512
+    cache 900 {
+        denial 9984 30
+    }
 }
 .:5353 {
     bufsize 512


### PR DESCRIPTION
Forward entries are missing a cache TTL on them, for larger environments with forwarded zones this can lead to heavier then expected load on DNS servers.