### PR TITLE
Add the namespace label for the CoreDNSErrorsHigh alert

### DIFF
--- a/manifests/0000_90_dns-operator_03_prometheusrules.yaml
+++ b/manifests/0000_90_dns-operator_03_prometheusrules.yaml
@@ -38,6 +38,7 @@ spec:
         for: 5m
         labels:
           severity: warning
+          namespace: openshift-dns-operator
         annotations:
           summary: CoreDNS serverfail
           description: "CoreDNS is returning SERVFAIL for {{ $value | humanizePercentage }} of requests."


### PR DESCRIPTION
This PR adds a `namespace` label to the CoreDNSErrorsHigh alert in order to conform to the [alert styling guide](https://github.com/openshift/enhancements/blob/master/enhancements/monitoring/alerting-consistency.md#style-guide).