### PR TITLE
Bug 2020489: Enable metrics for custom upstream resolvers

### DIFF
--- a/pkg/operator/controller/controller_dns_configmap.go
+++ b/pkg/operator/controller/controller_dns_configmap.go
@@ -27,6 +27,7 @@ var corefileTemplate = template.Must(template.New("Corefile").Funcs(template.Fun
 # {{.Name}}
 {{range .Zones}}{{.}}:5353 {{end}}{
     {{with .ForwardPlugin -}}
+    prometheus 127.0.0.1:9153
     forward .{{range .Upstreams}} {{.}}{{end}} {
         policy {{ CoreDNSForwardingPolicy .Policy }}
     }

--- a/pkg/operator/controller/controller_dns_configmap_test.go
+++ b/pkg/operator/controller/controller_dns_configmap_test.go
@@ -52,6 +52,7 @@ func TestDesiredDNSConfigmap(t *testing.T) {
 	}
 	expectedCorefile := `# foo
 foo.com:5353 {
+    prometheus 127.0.0.1:9153
     forward . 1.1.1.1 2.2.2.2:5353 {
         policy round_robin
     }
@@ -63,6 +64,7 @@ foo.com:5353 {
 }
 # bar
 bar.com:5353 example.com:5353 {
+    prometheus 127.0.0.1:9153
     forward . 3.3.3.3 {
         policy random
     }
@@ -74,6 +76,7 @@ bar.com:5353 example.com:5353 {
 }
 # fizz
 fizz.com:5353 {
+    prometheus 127.0.0.1:9153
     forward . 5.5.5.5 6.6.6.6 {
         policy sequential
     }
@@ -85,6 +88,7 @@ fizz.com:5353 {
 }
 # buzz
 buzz.com:5353 example.buzz.com:5353 {
+    prometheus 127.0.0.1:9153
     forward . 4.4.4.4 {
         policy random
     }


### PR DESCRIPTION
Before this change, the operator did not enable the "prometheus" plugin in server blocks for custom upstream resolvers.  As a consequence, CoreDNS did not report metrics for upstream resolvers and only reported metrics for the default server block.  This change enables the "prometheus" plugin for all server blocks.

* `pkg/operator/controller/controller_dns_configmap.go` (`corefileTemplate`): Add the "prometheus" plugin to server blocks for custom upstream resolvers.
* `pkg/operator/controller/controller_dns_configmap_test.go` (`TestDesiredDNSConfigmap`): Verify that `desiredDNSConfigMap` enables the "prometheus" plugin for all server blocks.