### PR TITLE
NE-815 Extract test Corefiles inside DNS ConfigMap test to individual files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,5 +105,7 @@ tags
 !.vscode/extensions.json
 .history
 
+### GoLand ###
+.idea/*
 
 # End of https://www.gitignore.io/api/go,vim,emacs,visualstudiocode

--- a/pkg/operator/controller/controller_dns_configmap_test.go
+++ b/pkg/operator/controller/controller_dns_configmap_test.go
@@ -2,6 +2,8 @@ package controller
 
 import (
 	"errors"
+	"io/ioutil"
+	"path"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -11,331 +13,137 @@ import (
 )
 
 func TestDesiredDNSConfigmap(t *testing.T) {
+	testCases := []struct {
+		name             string
+		dns              *operatorv1.DNS
+		expectedCoreFile string
+		expectedError    error
+	}{
+		{
+			name: "Check if Corefile is rendered correctly",
+			dns: &operatorv1.DNS{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: DefaultDNSController,
+				},
+				Spec: operatorv1.DNSSpec{
+					Servers: []operatorv1.Server{
+						{
+							Name:  "foo",
+							Zones: []string{"foo.com"},
+							ForwardPlugin: operatorv1.ForwardPlugin{
+								Upstreams: []string{"1.1.1.1", "2.2.2.2:5353"},
+								Policy:    operatorv1.RoundRobinForwardingPolicy,
+							},
+						},
+						{
+							Name:  "bar",
+							Zones: []string{"bar.com", "example.com"},
+							ForwardPlugin: operatorv1.ForwardPlugin{
+								Upstreams: []string{"3.3.3.3"},
+								Policy:    operatorv1.RandomForwardingPolicy,
+							},
+						},
+						{
+							Name:  "fizz",
+							Zones: []string{"fizz.com"},
+							ForwardPlugin: operatorv1.ForwardPlugin{
+								Upstreams: []string{"5.5.5.5", "6.6.6.6"},
+								Policy:    operatorv1.SequentialForwardingPolicy,
+							},
+						},
+						{
+							Name:  "buzz",
+							Zones: []string{"buzz.com", "example.buzz.com"},
+							ForwardPlugin: operatorv1.ForwardPlugin{
+								Upstreams: []string{"4.4.4.4"},
+							},
+						},
+					},
+				},
+			},
+			expectedCoreFile: mustLoadTestFile(t, "default_corefile"),
+		},
+		{
+			name: "Check if log level is set to normal",
+			dns: &operatorv1.DNS{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: DefaultDNSController,
+				},
+				Spec: operatorv1.DNSSpec{
+					Servers: []operatorv1.Server{
+						{
+							Name:  "foo",
+							Zones: []string{"foo.com"},
+							ForwardPlugin: operatorv1.ForwardPlugin{
+								Upstreams: []string{"1.1.1.1", "2.2.2.2:5353"},
+								Policy:    operatorv1.RoundRobinForwardingPolicy,
+							},
+						},
+					},
+					LogLevel: operatorv1.DNSLogLevelNormal,
+				},
+			},
+			expectedCoreFile: mustLoadTestFile(t, "normal_loglevel"),
+		},
+		{
+			name: "Check if log level is set to debug",
+			dns: &operatorv1.DNS{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: DefaultDNSController,
+				},
+				Spec: operatorv1.DNSSpec{
+					Servers: []operatorv1.Server{
+						{
+							Name:  "foo",
+							Zones: []string{"foo.com"},
+							ForwardPlugin: operatorv1.ForwardPlugin{
+								Upstreams: []string{"1.1.1.1", "2.2.2.2:5353"},
+								Policy:    operatorv1.RoundRobinForwardingPolicy,
+							},
+						},
+					},
+					LogLevel: operatorv1.DNSLogLevelDebug,
+				},
+			},
+			expectedCoreFile: mustLoadTestFile(t, "debug_loglevel"),
+		},
+		{
+			name: "Check if log level is set to trace",
+			dns: &operatorv1.DNS{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: DefaultDNSController,
+				},
+				Spec: operatorv1.DNSSpec{
+					Servers: []operatorv1.Server{
+						{
+							Name:  "foo",
+							Zones: []string{"foo.com"},
+							ForwardPlugin: operatorv1.ForwardPlugin{
+								Upstreams: []string{"1.1.1.1", "2.2.2.2:5353"},
+								Policy:    operatorv1.RoundRobinForwardingPolicy,
+							},
+						},
+					},
+					LogLevel: operatorv1.DNSLogLevelTrace,
+				},
+			},
+			expectedCoreFile: mustLoadTestFile(t, "trace_loglevel"),
+		},
+	}
+
 	clusterDomain := "cluster.local"
-	dns := &operatorv1.DNS{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: DefaultDNSController,
-		},
-		Spec: operatorv1.DNSSpec{
-			Servers: []operatorv1.Server{
-				{
-					Name:  "foo",
-					Zones: []string{"foo.com"},
-					ForwardPlugin: operatorv1.ForwardPlugin{
-						Upstreams: []string{"1.1.1.1", "2.2.2.2:5353"},
-						Policy:    operatorv1.RoundRobinForwardingPolicy,
-					},
-				},
-				{
-					Name:  "bar",
-					Zones: []string{"bar.com", "example.com"},
-					ForwardPlugin: operatorv1.ForwardPlugin{
-						Upstreams: []string{"3.3.3.3"},
-						Policy:    operatorv1.RandomForwardingPolicy,
-					},
-				},
-				{
-					Name:  "fizz",
-					Zones: []string{"fizz.com"},
-					ForwardPlugin: operatorv1.ForwardPlugin{
-						Upstreams: []string{"5.5.5.5", "6.6.6.6"},
-						Policy:    operatorv1.SequentialForwardingPolicy,
-					},
-				},
-				{
-					Name:  "buzz",
-					Zones: []string{"buzz.com", "example.buzz.com"},
-					ForwardPlugin: operatorv1.ForwardPlugin{
-						Upstreams: []string{"4.4.4.4"},
-					},
-				},
-			},
-		},
-	}
-	expectedCorefile := `# foo
-foo.com:5353 {
-    prometheus 127.0.0.1:9153
-    forward . 1.1.1.1 2.2.2.2:5353 {
-        policy round_robin
-    }
-    errors
-    log . {
-        class error
-    }
-    bufsize 512
-    cache 900 {
-        denial 9984 30
-    }
-}
-# bar
-bar.com:5353 example.com:5353 {
-    prometheus 127.0.0.1:9153
-    forward . 3.3.3.3 {
-        policy random
-    }
-    errors
-    log . {
-        class error
-    }
-    bufsize 512
-    cache 900 {
-        denial 9984 30
-    }
-}
-# fizz
-fizz.com:5353 {
-    prometheus 127.0.0.1:9153
-    forward . 5.5.5.5 6.6.6.6 {
-        policy sequential
-    }
-    errors
-    log . {
-        class error
-    }
-    bufsize 512
-    cache 900 {
-        denial 9984 30
-    }
-}
-# buzz
-buzz.com:5353 example.buzz.com:5353 {
-    prometheus 127.0.0.1:9153
-    forward . 4.4.4.4 {
-        policy random
-    }
-    errors
-    log . {
-        class error
-    }
-    bufsize 512
-    cache 900 {
-        denial 9984 30
-    }
-}
-.:5353 {
-    bufsize 512
-    errors
-    log . {
-        class error
-    }
-    health {
-        lameduck 20s
-    }
-    ready
-    kubernetes cluster.local in-addr.arpa ip6.arpa {
-        pods insecure
-        fallthrough in-addr.arpa ip6.arpa
-    }
-    prometheus 127.0.0.1:9153
-    forward . /etc/resolv.conf {
-        policy sequential
-    }
-    cache 900 {
-        denial 9984 30
-    }
-    reload
-}
-`
-	////////// Check if Normal Log Level is Set ////////////////
-
-	dnsToCheckNormalLogLevel := &operatorv1.DNS{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: DefaultDNSController,
-		},
-		Spec: operatorv1.DNSSpec{
-			Servers: []operatorv1.Server{
-				{
-					Name:  "foo",
-					Zones: []string{"foo.com"},
-					ForwardPlugin: operatorv1.ForwardPlugin{
-						Upstreams: []string{"1.1.1.1", "2.2.2.2:5353"},
-						Policy:    operatorv1.RoundRobinForwardingPolicy,
-					},
-				},
-			},
-			LogLevel: operatorv1.DNSLogLevelNormal,
-		},
-	}
-	expectedCorefileToCheckIfNormaLogLevelIsSet := `# foo
-foo.com:5353 {
-    prometheus 127.0.0.1:9153
-    forward . 1.1.1.1 2.2.2.2:5353 {
-        policy round_robin
-    }
-    errors
-    log . {
-        class error
-    }
-    bufsize 512
-    cache 900 {
-        denial 9984 30
-    }
-}
-.:5353 {
-    bufsize 512
-    errors
-    log . {
-        class error
-    }
-    health {
-        lameduck 20s
-    }
-    ready
-    kubernetes cluster.local in-addr.arpa ip6.arpa {
-        pods insecure
-        fallthrough in-addr.arpa ip6.arpa
-    }
-    prometheus 127.0.0.1:9153
-    forward . /etc/resolv.conf {
-        policy sequential
-    }
-    cache 900 {
-        denial 9984 30
-    }
-    reload
-}
-`
-
-	//// Check if Debug Level is set //////////////////
-
-	dnsToCheckDebugLogLevel := &operatorv1.DNS{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: DefaultDNSController,
-		},
-		Spec: operatorv1.DNSSpec{
-			Servers: []operatorv1.Server{
-				{
-					Name:  "foo",
-					Zones: []string{"foo.com"},
-					ForwardPlugin: operatorv1.ForwardPlugin{
-						Upstreams: []string{"1.1.1.1", "2.2.2.2:5353"},
-						Policy:    operatorv1.RoundRobinForwardingPolicy,
-					},
-				},
-			},
-			LogLevel: operatorv1.DNSLogLevelDebug,
-		},
-	}
-	expectedCorefileToCheckIfDebugLogLevelIsSet := `# foo
-		foo.com:5353 {
-		    prometheus 127.0.0.1:9153
-		    forward . 1.1.1.1 2.2.2.2:5353 {
-		        policy round_robin
-		    }
-		    errors
-            log . {
-                class denial error
-            }
-		    bufsize 512
-		    cache 900 {
-		        denial 9984 30
-		    }
-		}
-		.:5353 {
-		    bufsize 512
-		    errors
-            log . {
-                class denial error
-            }
-		    health {
-		        lameduck 20s
-		    }
-		    ready
-		    kubernetes cluster.local in-addr.arpa ip6.arpa {
-		        pods insecure
-		        fallthrough in-addr.arpa ip6.arpa
-		    }
-		    prometheus 127.0.0.1:9153
-		    forward . /etc/resolv.conf {
-		        policy sequential
-		    }
-		    cache 900 {
-		        denial 9984 30
-		    }
-		    reload
-		}
-		`
-	//// Check if Trace Level is set //////////////////
-	dnsToCheckTraceLogLevel := &operatorv1.DNS{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: DefaultDNSController,
-		},
-		Spec: operatorv1.DNSSpec{
-			Servers: []operatorv1.Server{
-				{
-					Name:  "foo",
-					Zones: []string{"foo.com"},
-					ForwardPlugin: operatorv1.ForwardPlugin{
-						Upstreams: []string{"1.1.1.1", "2.2.2.2:5353"},
-						Policy:    operatorv1.RoundRobinForwardingPolicy,
-					},
-				},
-			},
-			LogLevel: operatorv1.DNSLogLevelDebug,
-		},
-	}
-	expectedCorefileToCheckIfTraceLogLevelIsSet := `# foo
-foo.com:5353 {
-    prometheus 127.0.0.1:9153
-    forward . 1.1.1.1 2.2.2.2:5353 {
-        policy round_robin
-    }
-    errors
-    log . {
-        class all
-    }
-    bufsize 512
-    cache 900 {
-        denial 9984 30
-    }
-}
-.:5353 {
-    bufsize 512
-    errors
-    log . {
-        class all
-    }
-    health {
-        lameduck 20s
-    }
-    ready
-    kubernetes cluster.local in-addr.arpa ip6.arpa {
-        pods insecure
-        fallthrough in-addr.arpa ip6.arpa
-    }
-    prometheus 127.0.0.1:9153
-    forward . /etc/resolv.conf {
-        policy sequential
-    }
-    cache 900 {
-        denial 9984 30
-    }
-    reload
-}
-`
-
-	if cm, err := desiredDNSConfigMap(dns, clusterDomain); err != nil {
-		t.Errorf("invalid dns configmap: %v", err)
-	} else if cm.Data["Corefile"] != expectedCorefile {
-		t.Errorf("unexpected Corefile; got:\n%s\nexpected:\n%s\n", cm.Data["Corefile"], expectedCorefile)
-	}
-
-	if cmToCheckNormaLogLevel, err := desiredDNSConfigMap(dnsToCheckNormalLogLevel, clusterDomain); err != nil {
-		t.Errorf("invalid dns configmap: %v", err)
-	} else if cmToCheckNormaLogLevel.Data["Corefile"] != expectedCorefileToCheckIfNormaLogLevelIsSet {
-		t.Errorf("unexpected Corefile; got:\n%s\nexpected:\n%s\n", cmToCheckNormaLogLevel.Data["Corefile"], expectedCorefileToCheckIfNormaLogLevelIsSet)
-	}
-
-	if cmToCheckDebugLogLevel, err := desiredDNSConfigMap(dnsToCheckDebugLogLevel, clusterDomain); err != nil {
-		t.Errorf("invalid dns configmap: %v", err)
-	} else if cmToCheckDebugLogLevel.Data["Corefile"] == expectedCorefileToCheckIfDebugLogLevelIsSet {
-		t.Errorf("unexpected Corefile; got:\n%s\nexpected:\n%s\n", cmToCheckDebugLogLevel.Data["Corefile"], expectedCorefileToCheckIfDebugLogLevelIsSet)
-	}
-
-	if cmToCheckTraceLogLevel, err := desiredDNSConfigMap(dnsToCheckTraceLogLevel, clusterDomain); err != nil {
-		t.Errorf("invalid dns configmap: %v", err)
-	} else if cmToCheckTraceLogLevel.Data["Corefile"] == expectedCorefileToCheckIfTraceLogLevelIsSet {
-		t.Errorf("unexpected Corefile; got:\n%s\nexpected:\n%s\n", cmToCheckTraceLogLevel.Data["Corefile"], expectedCorefileToCheckIfTraceLogLevelIsSet)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if cm, err := desiredDNSConfigMap(tc.dns, clusterDomain); err != nil {
+				if !errors.Is(err, tc.expectedError) {
+					t.Errorf("Unexpected error : %v", err)
+				}
+			} else if tc.expectedError != nil {
+				t.Errorf("Error %v was expected", tc.expectedError)
+			} else if diff := cmp.Diff(cm.Data["Corefile"], tc.expectedCoreFile); diff != "" {
+				t.Errorf("unexpected Corefile;\n%s", diff)
+			}
+		})
 	}
 }
 
@@ -393,45 +201,7 @@ func TestDesiredDNSConfigmapUpstreamResolvers(t *testing.T) {
 					},
 				},
 			},
-			expectedCoreFile: `# foo
-foo.com:5353 {
-    prometheus 127.0.0.1:9153
-    forward . 1.1.1.1 2.2.2.2:5353 {
-        policy round_robin
-    }
-    errors
-    log . {
-        class error
-    }
-    bufsize 512
-    cache 900 {
-        denial 9984 30
-    }
-}
-.:5353 {
-    bufsize 512
-    errors
-    log . {
-        class error
-    }
-    health {
-        lameduck 20s
-    }
-    ready
-    kubernetes cluster.local in-addr.arpa ip6.arpa {
-        pods insecure
-        fallthrough in-addr.arpa ip6.arpa
-    }
-    prometheus 127.0.0.1:9153
-    forward . 1.2.3.4 9.8.7.6 [1001:AAAA:BBBB:CCCC::2222]:53 2.3.4.5:5353 127.0.0.53 {
-        policy round_robin
-    }
-    cache 900 {
-        denial 9984 30
-    }
-    reload
-}
-`,
+			expectedCoreFile: mustLoadTestFile(t, "5upstreams"),
 		},
 		{
 			name: "CR with upstreamResolvers containing just policy should return coreFile with default upstream /etc/resolv.conf and that policy",
@@ -455,45 +225,7 @@ foo.com:5353 {
 					},
 				},
 			},
-			expectedCoreFile: `# foo
-foo.com:5353 {
-    prometheus 127.0.0.1:9153
-    forward . 1.1.1.1 2.2.2.2:5353 {
-        policy round_robin
-    }
-    errors
-    log . {
-        class error
-    }
-    bufsize 512
-    cache 900 {
-        denial 9984 30
-    }
-}
-.:5353 {
-    bufsize 512
-    errors
-    log . {
-        class error
-    }
-    health {
-        lameduck 20s
-    }
-    ready
-    kubernetes cluster.local in-addr.arpa ip6.arpa {
-        pods insecure
-        fallthrough in-addr.arpa ip6.arpa
-    }
-    prometheus 127.0.0.1:9153
-    forward . /etc/resolv.conf {
-        policy round_robin
-    }
-    cache 900 {
-        denial 9984 30
-    }
-    reload
-}
-`,
+			expectedCoreFile: mustLoadTestFile(t, "just_policy"),
 		},
 		{
 			name: "CR with upstreamResolvers containing empty Upstreams array should return coreFile with default upstream /etc/resolv.conf and that policy",
@@ -518,45 +250,7 @@ foo.com:5353 {
 					},
 				},
 			},
-			expectedCoreFile: `# foo
-foo.com:5353 {
-    prometheus 127.0.0.1:9153
-    forward . 1.1.1.1 2.2.2.2:5353 {
-        policy round_robin
-    }
-    errors
-    log . {
-        class error
-    }
-    bufsize 512
-    cache 900 {
-        denial 9984 30
-    }
-}
-.:5353 {
-    bufsize 512
-    errors
-    log . {
-        class error
-    }
-    health {
-        lameduck 20s
-    }
-    ready
-    kubernetes cluster.local in-addr.arpa ip6.arpa {
-        pods insecure
-        fallthrough in-addr.arpa ip6.arpa
-    }
-    prometheus 127.0.0.1:9153
-    forward . /etc/resolv.conf {
-        policy round_robin
-    }
-    cache 900 {
-        denial 9984 30
-    }
-    reload
-}
-`,
+			expectedCoreFile: mustLoadTestFile(t, "empty_upstreams_array"),
 		},
 		{
 			name: "CR with upstreamResolvers containing a network upstream without address should return error",
@@ -615,45 +309,7 @@ foo.com:5353 {
 					},
 				},
 			},
-			expectedCoreFile: `# foo
-foo.com:5353 {
-    prometheus 127.0.0.1:9153
-    forward . 1.1.1.1 2.2.2.2:5353 {
-        policy round_robin
-    }
-    errors
-    log . {
-        class error
-    }
-    bufsize 512
-    cache 900 {
-        denial 9984 30
-    }
-}
-.:5353 {
-    bufsize 512
-    errors
-    log . {
-        class error
-    }
-    health {
-        lameduck 20s
-    }
-    ready
-    kubernetes cluster.local in-addr.arpa ip6.arpa {
-        pods insecure
-        fallthrough in-addr.arpa ip6.arpa
-    }
-    prometheus 127.0.0.1:9153
-    forward . 1.2.3.4 {
-        policy sequential
-    }
-    cache 900 {
-        denial 9984 30
-    }
-    reload
-}
-`,
+			expectedCoreFile: mustLoadTestFile(t, "1ns_no_policy"),
 		},
 		{
 			name: "CR with upstreamResolvers containing 1 Network NS and policy should return coreFile with 1 upstream defined and that policy",
@@ -683,45 +339,7 @@ foo.com:5353 {
 					},
 				},
 			},
-			expectedCoreFile: `# foo
-foo.com:5353 {
-    prometheus 127.0.0.1:9153
-    forward . 1.1.1.1 2.2.2.2:5353 {
-        policy round_robin
-    }
-    errors
-    log . {
-        class error
-    }
-    bufsize 512
-    cache 900 {
-        denial 9984 30
-    }
-}
-.:5353 {
-    bufsize 512
-    errors
-    log . {
-        class error
-    }
-    health {
-        lameduck 20s
-    }
-    ready
-    kubernetes cluster.local in-addr.arpa ip6.arpa {
-        pods insecure
-        fallthrough in-addr.arpa ip6.arpa
-    }
-    prometheus 127.0.0.1:9153
-    forward . 1.2.3.4 {
-        policy random
-    }
-    cache 900 {
-        denial 9984 30
-    }
-    reload
-}
-`,
+			expectedCoreFile: mustLoadTestFile(t, "1ns_and_policy"),
 		},
 		{
 			name: "CR with duplicates in upstreamResolvers.upstreams should return coreFile without duplicates",
@@ -778,45 +396,7 @@ foo.com:5353 {
 					},
 				},
 			},
-			expectedCoreFile: `# foo
-foo.com:5353 {
-    prometheus 127.0.0.1:9153
-    forward . 1.1.1.1 2.2.2.2:5353 {
-        policy round_robin
-    }
-    errors
-    log . {
-        class error
-    }
-    bufsize 512
-    cache 900 {
-        denial 9984 30
-    }
-}
-.:5353 {
-    bufsize 512
-    errors
-    log . {
-        class error
-    }
-    health {
-        lameduck 20s
-    }
-    ready
-    kubernetes cluster.local in-addr.arpa ip6.arpa {
-        pods insecure
-        fallthrough in-addr.arpa ip6.arpa
-    }
-    prometheus 127.0.0.1:9153
-    forward . /etc/resolv.conf [1001:AAAA:BBBB:CCCC::2222]:5353 10.0.0.1:53 [1001:AAAA:BBBB:CCCC::2222]:5354 {
-        policy random
-    }
-    cache 900 {
-        denial 9984 30
-    }
-    reload
-}
-`,
+			expectedCoreFile: mustLoadTestFile(t, "duplicate_upstreams"),
 		},
 		{
 			name: "CR with upstreamResolvers.upstreams of type empty should return coreFile without duplicate /etc/resolv.conf",
@@ -870,45 +450,7 @@ foo.com:5353 {
 					},
 				},
 			},
-			expectedCoreFile: `# foo
-foo.com:5353 {
-    prometheus 127.0.0.1:9153
-    forward . 1.1.1.1 2.2.2.2:5353 {
-        policy round_robin
-    }
-    errors
-    log . {
-        class error
-    }
-    bufsize 512
-    cache 900 {
-        denial 9984 30
-    }
-}
-.:5353 {
-    bufsize 512
-    errors
-    log . {
-        class error
-    }
-    health {
-        lameduck 20s
-    }
-    ready
-    kubernetes cluster.local in-addr.arpa ip6.arpa {
-        pods insecure
-        fallthrough in-addr.arpa ip6.arpa
-    }
-    prometheus 127.0.0.1:9153
-    forward . /etc/resolv.conf 100.1.1.1:5500 [1000::100]:53 {
-        policy random
-    }
-    cache 900 {
-        denial 9984 30
-    }
-    reload
-}
-`,
+			expectedCoreFile: mustLoadTestFile(t, "upstreams_type_empty"),
 		},
 		{
 			name: "CR with upstreamResolvers containing 1 SystemResolvConf NS and policy should return a coreFile with 1 upstream defined and that policy",
@@ -937,45 +479,7 @@ foo.com:5353 {
 					},
 				},
 			},
-			expectedCoreFile: `# foo
-foo.com:5353 {
-    prometheus 127.0.0.1:9153
-    forward . 1.1.1.1 2.2.2.2:5353 {
-        policy round_robin
-    }
-    errors
-    log . {
-        class error
-    }
-    bufsize 512
-    cache 900 {
-        denial 9984 30
-    }
-}
-.:5353 {
-    bufsize 512
-    errors
-    log . {
-        class error
-    }
-    health {
-        lameduck 20s
-    }
-    ready
-    kubernetes cluster.local in-addr.arpa ip6.arpa {
-        pods insecure
-        fallthrough in-addr.arpa ip6.arpa
-    }
-    prometheus 127.0.0.1:9153
-    forward . /etc/resolv.conf {
-        policy random
-    }
-    cache 900 {
-        denial 9984 30
-    }
-    reload
-}
-`,
+			expectedCoreFile: mustLoadTestFile(t, "1sysresconf"),
 		},
 		{
 			name: "CR without upstreamResolvers defined should return coreFile with forwardPlugin upstream /etc/resolv.conf in sequential policy",
@@ -996,45 +500,7 @@ foo.com:5353 {
 					},
 				},
 			},
-			expectedCoreFile: `# foo
-foo.com:5353 {
-    prometheus 127.0.0.1:9153
-    forward . 1.1.1.1 2.2.2.2:5353 {
-        policy round_robin
-    }
-    errors
-    log . {
-        class error
-    }
-    bufsize 512
-    cache 900 {
-        denial 9984 30
-    }
-}
-.:5353 {
-    bufsize 512
-    errors
-    log . {
-        class error
-    }
-    health {
-        lameduck 20s
-    }
-    ready
-    kubernetes cluster.local in-addr.arpa ip6.arpa {
-        pods insecure
-        fallthrough in-addr.arpa ip6.arpa
-    }
-    prometheus 127.0.0.1:9153
-    forward . /etc/resolv.conf {
-        policy sequential
-    }
-    cache 900 {
-        denial 9984 30
-    }
-    reload
-}
-`,
+			expectedCoreFile: mustLoadTestFile(t, "without_upstreamresolvers"),
 		},
 		{
 			name: "CR with multiple upstreamResolvers, of which /etc/resolv.conf is one, should return Corefile with all the upstreams",
@@ -1067,48 +533,10 @@ foo.com:5353 {
 					},
 				},
 			},
-			expectedCoreFile: `# foo
-foo.com:5353 {
-    prometheus 127.0.0.1:9153
-    forward . 1.1.1.1 2.2.2.2:5353 {
-        policy round_robin
-    }
-    errors
-    log . {
-        class error
-    }
-    bufsize 512
-    cache 900 {
-        denial 9984 30
-    }
-}
-.:5353 {
-    bufsize 512
-    errors
-    log . {
-        class error
-    }
-    health {
-        lameduck 20s
-    }
-    ready
-    kubernetes cluster.local in-addr.arpa ip6.arpa {
-        pods insecure
-        fallthrough in-addr.arpa ip6.arpa
-    }
-    prometheus 127.0.0.1:9153
-    forward . /etc/resolv.conf 1.3.4.5 {
-        policy random
-    }
-    cache 900 {
-        denial 9984 30
-    }
-    reload
-}
-`,
+			expectedCoreFile: mustLoadTestFile(t, "mult_upstreamresolvers"),
 		},
 		{
-			name: "CR with upstreamResolvers containing 1 SystemResolvConf NS with Address  should return coreFile with 1 /etc/resolv.conf ignoring Address",
+			name: "CR with upstreamResolvers containing 1 SystemResolvConf NS with Address should return coreFile with 1 /etc/resolv.conf ignoring Address",
 			dns: &operatorv1.DNS{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: DefaultDNSController,
@@ -1135,45 +563,7 @@ foo.com:5353 {
 					},
 				},
 			},
-			expectedCoreFile: `# foo
-foo.com:5353 {
-    prometheus 127.0.0.1:9153
-    forward . 1.1.1.1 2.2.2.2:5353 {
-        policy round_robin
-    }
-    errors
-    log . {
-        class error
-    }
-    bufsize 512
-    cache 900 {
-        denial 9984 30
-    }
-}
-.:5353 {
-    bufsize 512
-    errors
-    log . {
-        class error
-    }
-    health {
-        lameduck 20s
-    }
-    ready
-    kubernetes cluster.local in-addr.arpa ip6.arpa {
-        pods insecure
-        fallthrough in-addr.arpa ip6.arpa
-    }
-    prometheus 127.0.0.1:9153
-    forward . /etc/resolv.conf {
-        policy random
-    }
-    cache 900 {
-        denial 9984 30
-    }
-    reload
-}
-`,
+			expectedCoreFile: mustLoadTestFile(t, "1sysresconf"),
 		},
 		{
 			name: "CR with upstreamResolvers containing 1 SystemResolvConf NS with Port should return coreFile with 1 /etc/resolv.conf ignoring port",
@@ -1203,45 +593,7 @@ foo.com:5353 {
 					},
 				},
 			},
-			expectedCoreFile: `# foo
-foo.com:5353 {
-    prometheus 127.0.0.1:9153
-    forward . 1.1.1.1 2.2.2.2:5353 {
-        policy round_robin
-    }
-    errors
-    log . {
-        class error
-    }
-    bufsize 512
-    cache 900 {
-        denial 9984 30
-    }
-}
-.:5353 {
-    bufsize 512
-    errors
-    log . {
-        class error
-    }
-    health {
-        lameduck 20s
-    }
-    ready
-    kubernetes cluster.local in-addr.arpa ip6.arpa {
-        pods insecure
-        fallthrough in-addr.arpa ip6.arpa
-    }
-    prometheus 127.0.0.1:9153
-    forward . /etc/resolv.conf {
-        policy random
-    }
-    cache 900 {
-        denial 9984 30
-    }
-    reload
-}
-`,
+			expectedCoreFile: mustLoadTestFile(t, "1sysresconf"),
 		},
 		{
 			name: "CR with upstreamResolvers containing 1 Network IPv6 NS and policy should return coreFile with 1 upstream defined and that policy",
@@ -1271,45 +623,7 @@ foo.com:5353 {
 					},
 				},
 			},
-			expectedCoreFile: `# foo
-foo.com:5353 {
-    prometheus 127.0.0.1:9153
-    forward . 1.1.1.1 2.2.2.2:5353 {
-        policy round_robin
-    }
-    errors
-    log . {
-        class error
-    }
-    bufsize 512
-    cache 900 {
-        denial 9984 30
-    }
-}
-.:5353 {
-    bufsize 512
-    errors
-    log . {
-        class error
-    }
-    health {
-        lameduck 20s
-    }
-    ready
-    kubernetes cluster.local in-addr.arpa ip6.arpa {
-        pods insecure
-        fallthrough in-addr.arpa ip6.arpa
-    }
-    prometheus 127.0.0.1:9153
-    forward . 1001:AAAA:BBBB:CCCC::2222 {
-        policy random
-    }
-    cache 900 {
-        denial 9984 30
-    }
-    reload
-}
-`,
+			expectedCoreFile: mustLoadTestFile(t, "1ipv6_and_policy"),
 		},
 	}
 
@@ -1328,4 +642,15 @@ foo.com:5353 {
 			}
 		})
 	}
+}
+
+// mustLoadTestFile looks in the default directory of ./testdata for a file matching the name argument
+// and returns the file contents as a string.
+func mustLoadTestFile(t *testing.T, name string) string {
+	t.Helper()
+	corefile, err := ioutil.ReadFile(path.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("Failed to read Corefile %s: %v", name, err)
+	}
+	return string(corefile)
 }

--- a/pkg/operator/controller/testdata/1ipv6_and_policy
+++ b/pkg/operator/controller/testdata/1ipv6_and_policy
@@ -1,0 +1,38 @@
+# foo
+foo.com:5353 {
+    prometheus 127.0.0.1:9153
+    forward . 1.1.1.1 2.2.2.2:5353 {
+        policy round_robin
+    }
+    errors
+    log . {
+        class error
+    }
+    bufsize 512
+    cache 900 {
+        denial 9984 30
+    }
+}
+.:5353 {
+    bufsize 512
+    errors
+    log . {
+        class error
+    }
+    health {
+        lameduck 20s
+    }
+    ready
+    kubernetes cluster.local in-addr.arpa ip6.arpa {
+        pods insecure
+        fallthrough in-addr.arpa ip6.arpa
+    }
+    prometheus 127.0.0.1:9153
+    forward . 1001:AAAA:BBBB:CCCC::2222 {
+        policy random
+    }
+    cache 900 {
+        denial 9984 30
+    }
+    reload
+}

--- a/pkg/operator/controller/testdata/1ns_and_policy
+++ b/pkg/operator/controller/testdata/1ns_and_policy
@@ -1,0 +1,38 @@
+# foo
+foo.com:5353 {
+    prometheus 127.0.0.1:9153
+    forward . 1.1.1.1 2.2.2.2:5353 {
+        policy round_robin
+    }
+    errors
+    log . {
+        class error
+    }
+    bufsize 512
+    cache 900 {
+        denial 9984 30
+    }
+}
+.:5353 {
+    bufsize 512
+    errors
+    log . {
+        class error
+    }
+    health {
+        lameduck 20s
+    }
+    ready
+    kubernetes cluster.local in-addr.arpa ip6.arpa {
+        pods insecure
+        fallthrough in-addr.arpa ip6.arpa
+    }
+    prometheus 127.0.0.1:9153
+    forward . 1.2.3.4 {
+        policy random
+    }
+    cache 900 {
+        denial 9984 30
+    }
+    reload
+}

--- a/pkg/operator/controller/testdata/1ns_no_policy
+++ b/pkg/operator/controller/testdata/1ns_no_policy
@@ -1,0 +1,38 @@
+# foo
+foo.com:5353 {
+    prometheus 127.0.0.1:9153
+    forward . 1.1.1.1 2.2.2.2:5353 {
+        policy round_robin
+    }
+    errors
+    log . {
+        class error
+    }
+    bufsize 512
+    cache 900 {
+        denial 9984 30
+    }
+}
+.:5353 {
+    bufsize 512
+    errors
+    log . {
+        class error
+    }
+    health {
+        lameduck 20s
+    }
+    ready
+    kubernetes cluster.local in-addr.arpa ip6.arpa {
+        pods insecure
+        fallthrough in-addr.arpa ip6.arpa
+    }
+    prometheus 127.0.0.1:9153
+    forward . 1.2.3.4 {
+        policy sequential
+    }
+    cache 900 {
+        denial 9984 30
+    }
+    reload
+}

--- a/pkg/operator/controller/testdata/1sysresconf
+++ b/pkg/operator/controller/testdata/1sysresconf
@@ -1,0 +1,38 @@
+# foo
+foo.com:5353 {
+    prometheus 127.0.0.1:9153
+    forward . 1.1.1.1 2.2.2.2:5353 {
+        policy round_robin
+    }
+    errors
+    log . {
+        class error
+    }
+    bufsize 512
+    cache 900 {
+        denial 9984 30
+    }
+}
+.:5353 {
+    bufsize 512
+    errors
+    log . {
+        class error
+    }
+    health {
+        lameduck 20s
+    }
+    ready
+    kubernetes cluster.local in-addr.arpa ip6.arpa {
+        pods insecure
+        fallthrough in-addr.arpa ip6.arpa
+    }
+    prometheus 127.0.0.1:9153
+    forward . /etc/resolv.conf {
+        policy random
+    }
+    cache 900 {
+        denial 9984 30
+    }
+    reload
+}

--- a/pkg/operator/controller/testdata/5upstreams
+++ b/pkg/operator/controller/testdata/5upstreams
@@ -1,0 +1,38 @@
+# foo
+foo.com:5353 {
+    prometheus 127.0.0.1:9153
+    forward . 1.1.1.1 2.2.2.2:5353 {
+        policy round_robin
+    }
+    errors
+    log . {
+        class error
+    }
+    bufsize 512
+    cache 900 {
+        denial 9984 30
+    }
+}
+.:5353 {
+    bufsize 512
+    errors
+    log . {
+        class error
+    }
+    health {
+        lameduck 20s
+    }
+    ready
+    kubernetes cluster.local in-addr.arpa ip6.arpa {
+        pods insecure
+        fallthrough in-addr.arpa ip6.arpa
+    }
+    prometheus 127.0.0.1:9153
+    forward . 1.2.3.4 9.8.7.6 [1001:AAAA:BBBB:CCCC::2222]:53 2.3.4.5:5353 127.0.0.53 {
+        policy round_robin
+    }
+    cache 900 {
+        denial 9984 30
+    }
+    reload
+}

--- a/pkg/operator/controller/testdata/debug_loglevel
+++ b/pkg/operator/controller/testdata/debug_loglevel
@@ -1,0 +1,38 @@
+# foo
+foo.com:5353 {
+    prometheus 127.0.0.1:9153
+    forward . 1.1.1.1 2.2.2.2:5353 {
+        policy round_robin
+    }
+    errors
+    log . {
+        class denial error
+    }
+    bufsize 512
+    cache 900 {
+        denial 9984 30
+    }
+}
+.:5353 {
+    bufsize 512
+    errors
+    log . {
+        class denial error
+    }
+    health {
+        lameduck 20s
+    }
+    ready
+    kubernetes cluster.local in-addr.arpa ip6.arpa {
+        pods insecure
+        fallthrough in-addr.arpa ip6.arpa
+    }
+    prometheus 127.0.0.1:9153
+    forward . /etc/resolv.conf {
+        policy sequential
+    }
+    cache 900 {
+        denial 9984 30
+    }
+    reload
+}

--- a/pkg/operator/controller/testdata/default_corefile
+++ b/pkg/operator/controller/testdata/default_corefile
@@ -1,0 +1,83 @@
+# foo
+foo.com:5353 {
+    prometheus 127.0.0.1:9153
+    forward . 1.1.1.1 2.2.2.2:5353 {
+        policy round_robin
+    }
+    errors
+    log . {
+        class error
+    }
+    bufsize 512
+    cache 900 {
+        denial 9984 30
+    }
+}
+# bar
+bar.com:5353 example.com:5353 {
+    prometheus 127.0.0.1:9153
+    forward . 3.3.3.3 {
+        policy random
+    }
+    errors
+    log . {
+        class error
+    }
+    bufsize 512
+    cache 900 {
+        denial 9984 30
+    }
+}
+# fizz
+fizz.com:5353 {
+    prometheus 127.0.0.1:9153
+    forward . 5.5.5.5 6.6.6.6 {
+        policy sequential
+    }
+    errors
+    log . {
+        class error
+    }
+    bufsize 512
+    cache 900 {
+        denial 9984 30
+    }
+}
+# buzz
+buzz.com:5353 example.buzz.com:5353 {
+    prometheus 127.0.0.1:9153
+    forward . 4.4.4.4 {
+        policy random
+    }
+    errors
+    log . {
+        class error
+    }
+    bufsize 512
+    cache 900 {
+        denial 9984 30
+    }
+}
+.:5353 {
+    bufsize 512
+    errors
+    log . {
+        class error
+    }
+    health {
+        lameduck 20s
+    }
+    ready
+    kubernetes cluster.local in-addr.arpa ip6.arpa {
+        pods insecure
+        fallthrough in-addr.arpa ip6.arpa
+    }
+    prometheus 127.0.0.1:9153
+    forward . /etc/resolv.conf {
+        policy sequential
+    }
+    cache 900 {
+        denial 9984 30
+    }
+    reload
+}

--- a/pkg/operator/controller/testdata/duplicate_upstreams
+++ b/pkg/operator/controller/testdata/duplicate_upstreams
@@ -1,0 +1,38 @@
+# foo
+foo.com:5353 {
+    prometheus 127.0.0.1:9153
+    forward . 1.1.1.1 2.2.2.2:5353 {
+        policy round_robin
+    }
+    errors
+    log . {
+        class error
+    }
+    bufsize 512
+    cache 900 {
+        denial 9984 30
+    }
+}
+.:5353 {
+    bufsize 512
+    errors
+    log . {
+        class error
+    }
+    health {
+        lameduck 20s
+    }
+    ready
+    kubernetes cluster.local in-addr.arpa ip6.arpa {
+        pods insecure
+        fallthrough in-addr.arpa ip6.arpa
+    }
+    prometheus 127.0.0.1:9153
+    forward . /etc/resolv.conf [1001:AAAA:BBBB:CCCC::2222]:5353 10.0.0.1:53 [1001:AAAA:BBBB:CCCC::2222]:5354 {
+        policy random
+    }
+    cache 900 {
+        denial 9984 30
+    }
+    reload
+}

--- a/pkg/operator/controller/testdata/empty_upstreams_array
+++ b/pkg/operator/controller/testdata/empty_upstreams_array
@@ -1,0 +1,38 @@
+# foo
+foo.com:5353 {
+    prometheus 127.0.0.1:9153
+    forward . 1.1.1.1 2.2.2.2:5353 {
+        policy round_robin
+    }
+    errors
+    log . {
+        class error
+    }
+    bufsize 512
+    cache 900 {
+        denial 9984 30
+    }
+}
+.:5353 {
+    bufsize 512
+    errors
+    log . {
+        class error
+    }
+    health {
+        lameduck 20s
+    }
+    ready
+    kubernetes cluster.local in-addr.arpa ip6.arpa {
+        pods insecure
+        fallthrough in-addr.arpa ip6.arpa
+    }
+    prometheus 127.0.0.1:9153
+    forward . /etc/resolv.conf {
+        policy round_robin
+    }
+    cache 900 {
+        denial 9984 30
+    }
+    reload
+}

--- a/pkg/operator/controller/testdata/just_policy
+++ b/pkg/operator/controller/testdata/just_policy
@@ -1,0 +1,38 @@
+# foo
+foo.com:5353 {
+    prometheus 127.0.0.1:9153
+    forward . 1.1.1.1 2.2.2.2:5353 {
+        policy round_robin
+    }
+    errors
+    log . {
+        class error
+    }
+    bufsize 512
+    cache 900 {
+        denial 9984 30
+    }
+}
+.:5353 {
+    bufsize 512
+    errors
+    log . {
+        class error
+    }
+    health {
+        lameduck 20s
+    }
+    ready
+    kubernetes cluster.local in-addr.arpa ip6.arpa {
+        pods insecure
+        fallthrough in-addr.arpa ip6.arpa
+    }
+    prometheus 127.0.0.1:9153
+    forward . /etc/resolv.conf {
+        policy round_robin
+    }
+    cache 900 {
+        denial 9984 30
+    }
+    reload
+}

--- a/pkg/operator/controller/testdata/mult_upstreamresolvers
+++ b/pkg/operator/controller/testdata/mult_upstreamresolvers
@@ -1,0 +1,38 @@
+# foo
+foo.com:5353 {
+    prometheus 127.0.0.1:9153
+    forward . 1.1.1.1 2.2.2.2:5353 {
+        policy round_robin
+    }
+    errors
+    log . {
+        class error
+    }
+    bufsize 512
+    cache 900 {
+        denial 9984 30
+    }
+}
+.:5353 {
+    bufsize 512
+    errors
+    log . {
+        class error
+    }
+    health {
+        lameduck 20s
+    }
+    ready
+    kubernetes cluster.local in-addr.arpa ip6.arpa {
+        pods insecure
+        fallthrough in-addr.arpa ip6.arpa
+    }
+    prometheus 127.0.0.1:9153
+    forward . /etc/resolv.conf 1.3.4.5 {
+        policy random
+    }
+    cache 900 {
+        denial 9984 30
+    }
+    reload
+}

--- a/pkg/operator/controller/testdata/normal_loglevel
+++ b/pkg/operator/controller/testdata/normal_loglevel
@@ -1,0 +1,38 @@
+# foo
+foo.com:5353 {
+    prometheus 127.0.0.1:9153
+    forward . 1.1.1.1 2.2.2.2:5353 {
+        policy round_robin
+    }
+    errors
+    log . {
+        class error
+    }
+    bufsize 512
+    cache 900 {
+        denial 9984 30
+    }
+}
+.:5353 {
+    bufsize 512
+    errors
+    log . {
+        class error
+    }
+    health {
+        lameduck 20s
+    }
+    ready
+    kubernetes cluster.local in-addr.arpa ip6.arpa {
+        pods insecure
+        fallthrough in-addr.arpa ip6.arpa
+    }
+    prometheus 127.0.0.1:9153
+    forward . /etc/resolv.conf {
+        policy sequential
+    }
+    cache 900 {
+        denial 9984 30
+    }
+    reload
+}

--- a/pkg/operator/controller/testdata/trace_loglevel
+++ b/pkg/operator/controller/testdata/trace_loglevel
@@ -1,0 +1,38 @@
+# foo
+foo.com:5353 {
+    prometheus 127.0.0.1:9153
+    forward . 1.1.1.1 2.2.2.2:5353 {
+        policy round_robin
+    }
+    errors
+    log . {
+        class all
+    }
+    bufsize 512
+    cache 900 {
+        denial 9984 30
+    }
+}
+.:5353 {
+    bufsize 512
+    errors
+    log . {
+        class all
+    }
+    health {
+        lameduck 20s
+    }
+    ready
+    kubernetes cluster.local in-addr.arpa ip6.arpa {
+        pods insecure
+        fallthrough in-addr.arpa ip6.arpa
+    }
+    prometheus 127.0.0.1:9153
+    forward . /etc/resolv.conf {
+        policy sequential
+    }
+    cache 900 {
+        denial 9984 30
+    }
+    reload
+}

--- a/pkg/operator/controller/testdata/upstreams_type_empty
+++ b/pkg/operator/controller/testdata/upstreams_type_empty
@@ -1,0 +1,38 @@
+# foo
+foo.com:5353 {
+    prometheus 127.0.0.1:9153
+    forward . 1.1.1.1 2.2.2.2:5353 {
+        policy round_robin
+    }
+    errors
+    log . {
+        class error
+    }
+    bufsize 512
+    cache 900 {
+        denial 9984 30
+    }
+}
+.:5353 {
+    bufsize 512
+    errors
+    log . {
+        class error
+    }
+    health {
+        lameduck 20s
+    }
+    ready
+    kubernetes cluster.local in-addr.arpa ip6.arpa {
+        pods insecure
+        fallthrough in-addr.arpa ip6.arpa
+    }
+    prometheus 127.0.0.1:9153
+    forward . /etc/resolv.conf 100.1.1.1:5500 [1000::100]:53 {
+        policy random
+    }
+    cache 900 {
+        denial 9984 30
+    }
+    reload
+}

--- a/pkg/operator/controller/testdata/without_upstreamresolvers
+++ b/pkg/operator/controller/testdata/without_upstreamresolvers
@@ -1,0 +1,38 @@
+# foo
+foo.com:5353 {
+    prometheus 127.0.0.1:9153
+    forward . 1.1.1.1 2.2.2.2:5353 {
+        policy round_robin
+    }
+    errors
+    log . {
+        class error
+    }
+    bufsize 512
+    cache 900 {
+        denial 9984 30
+    }
+}
+.:5353 {
+    bufsize 512
+    errors
+    log . {
+        class error
+    }
+    health {
+        lameduck 20s
+    }
+    ready
+    kubernetes cluster.local in-addr.arpa ip6.arpa {
+        pods insecure
+        fallthrough in-addr.arpa ip6.arpa
+    }
+    prometheus 127.0.0.1:9153
+    forward . /etc/resolv.conf {
+        policy sequential
+    }
+    cache 900 {
+        denial 9984 30
+    }
+    reload
+}


### PR DESCRIPTION
Moving all the test Corefiles from `controller_dns_configmap_test.go` to individual files under `test-corefiles` directory. This improves code readibility and makes it easier to handle the Corefiles. This also removes duplicate Corefiles for multiple cases, and instead use the same file for all the relevant cases.

Co-authored-by: Chad Scribner <chad@redhat.com>