### PR TITLE
AUTH-182: manifests/deployment: comply to restricted pod security level

### DIFF
--- a/manifests/0000_70_dns-operator_02-deployment-ibm-cloud-managed.yaml
+++ b/manifests/0000_70_dns-operator_02-deployment-ibm-cloud-managed.yaml
@@ -36,6 +36,11 @@ spec:
           requests:
             cpu: 10m
             memory: 29Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         terminationMessagePolicy: FallbackToLogsOnError
       - args:
         - --logtostderr
@@ -53,6 +58,11 @@ spec:
           requests:
             cpu: 10m
             memory: 40Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         volumeMounts:
         - mountPath: /etc/tls/private
           name: metrics-tls
@@ -62,6 +72,11 @@ spec:
         kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
       restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: dns-operator
       terminationGracePeriodSeconds: 2
       tolerations:

--- a/manifests/0000_70_dns-operator_02-deployment.yaml
+++ b/manifests/0000_70_dns-operator_02-deployment.yaml
@@ -23,6 +23,11 @@ spec:
         kubernetes.io/os: linux
         node-role.kubernetes.io/master: ''
       restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       priorityClassName: system-cluster-critical
       serviceAccountName: dns-operator
       containers:
@@ -44,6 +49,11 @@ spec:
           requests:
             cpu: 10m
             memory: 29Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
       - name: kube-rbac-proxy
         image: quay.io/openshift/origin-kube-rbac-proxy:latest
         args:
@@ -60,6 +70,11 @@ spec:
           requests:
             cpu: 10m
             memory: 40Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         volumeMounts:
         - mountPath: /etc/tls/private
           name: metrics-tls


### PR DESCRIPTION
Starting from OpenShift 4.11 pod security admission is being activated. In OpenShift the default pod security admission level is going to be `restricted`. This PR fixes workloads from this repository. Concretely, the following violations have been detected:

```
{
  "objectRef": "openshift-dns-operator/deployments/dns-operator",
  "pod-security.kubernetes.io/audit-violations": "would violate PodSecurity \"restricted:latest\": allowPrivilegeEscalation != false (containers \"dns-operator\", \"kube-rbac-proxy\" must set securityContext.allowPrivilegeEscalation=false), unre
stricted capabilities (containers \"dns-operator\", \"kube-rbac-proxy\" must set securityContext.capabilities.drop=[\"ALL\"]), runAsNonRoot != true (pod or containers \"dns-operator\", \"kube-rbac-proxy\" must set securityContext.runAsNonRoot=tr
ue), seccompProfile (pod or containers \"dns-operator\", \"kube-rbac-proxy\" must set securityContext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")"
}
```

/cc @stlaz 