### PR TITLE
Bug 2092509: Append an error when a non-existent configmap is configured for DNS-over-TLS

### DIFF
--- a/pkg/operator/controller/controller_cabundle_configmap.go
+++ b/pkg/operator/controller/controller_cabundle_configmap.go
@@ -64,14 +64,18 @@ func (r *reconciler) ensureCABundleConfigMaps(dns *operatorv1.DNS) error {
 		}
 		haveSource, source, err := r.currentCABundleConfigMap(sourceName)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("failed to get source ca bundle config map %s: %w", sourceName.Name, err))
+			errs = append(errs, fmt.Errorf("failed to get source ca bundle configmap %s: %w", sourceName.Name, err))
+			continue
+		}
+		if !haveSource {
+			logrus.Warningf("source ca bundle configmap %s does not exist", sourceName.Name)
 			continue
 		}
 
 		destName := CABundleConfigMapName(source.Name)
 		have, current, err := r.currentCABundleConfigMap(destName)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("failed to get destination ca bundle config map %s: %w", destName.Name, err))
+			errs = append(errs, fmt.Errorf("failed to get destination ca bundle configmap %s: %w", destName.Name, err))
 			continue
 		}
 

--- a/pkg/operator/controller/controller_cabundle_configmap_test.go
+++ b/pkg/operator/controller/controller_cabundle_configmap_test.go
@@ -30,16 +30,16 @@ func TestDesiredCABundleConfigmap(t *testing.T) {
 
 	desired, cm, err := desiredCABundleConfigMap(dns, true, &sourceConfigmap, destName)
 	if err != nil || desired == false {
-		t.Errorf("Unexpected error : %v", err)
+		t.Errorf("unexpected error : %v", err)
 	} else if diff := cmp.Diff(cm.Data, sourceConfigmap.Data); diff != "" {
-		t.Errorf("Unexpected CA Bundle ConfigMap data;\n%s", diff)
+		t.Errorf("unexpected CA Bundle ConfigMap data;\n%s", diff)
 	} else if diff := cmp.Diff(cm.OwnerReferences, []metav1.OwnerReference{dnsOwnerRef(dns)}); diff != "" {
-		t.Errorf("Unexpected CA Bundle ConfigMap OwnerReference;\n%s", diff)
+		t.Errorf("unexpected CA Bundle ConfigMap OwnerReference;\n%s", diff)
 	}
 
 	desired, cm, err = desiredCABundleConfigMap(dns, false, &sourceConfigmap, destName)
 	if desired != false || cm != nil || err != nil {
-		t.Errorf("Unexpected error : %v", err)
+		t.Errorf("expected return values of false, nil, nil when haveSource is false: %v", err)
 	}
 
 	var delTimestamp *metav1.Time
@@ -50,6 +50,6 @@ func TestDesiredCABundleConfigmap(t *testing.T) {
 
 	desired, cm, err = desiredCABundleConfigMap(dns, true, &sourceConfigmap, destName)
 	if desired != false || cm != nil || err != nil {
-		t.Errorf("Unexpected error : %v", err)
+		t.Errorf("expected return values of false, nil, nil when dns.DeletionTimestamp is not nil: %v", err)
 	}
 }

--- a/pkg/operator/controller/controller_cabundle_configmap_test.go
+++ b/pkg/operator/controller/controller_cabundle_configmap_test.go
@@ -1,13 +1,12 @@
 package controller
 
 import (
-	"testing"
-
 	"github.com/google/go-cmp/cmp"
 	operatorv1 "github.com/openshift/api/operator/v1"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+	"time"
 )
 
 func TestDesiredCABundleConfigmap(t *testing.T) {
@@ -28,12 +27,28 @@ func TestDesiredCABundleConfigmap(t *testing.T) {
 		Spec: operatorv1.DNSSpec{},
 	}
 
-	_, cm, err := desiredCABundleConfigMap(dns, true, &sourceConfigmap, destName)
-	if err != nil {
+	desired, cm, err := desiredCABundleConfigMap(dns, true, &sourceConfigmap, destName)
+	if err != nil || desired == false {
 		t.Errorf("Unexpected error : %v", err)
 	} else if diff := cmp.Diff(cm.Data, sourceConfigmap.Data); diff != "" {
 		t.Errorf("Unexpected CA Bundle ConfigMap data;\n%s", diff)
 	} else if diff := cmp.Diff(cm.OwnerReferences, []metav1.OwnerReference{dnsOwnerRef(dns)}); diff != "" {
 		t.Errorf("Unexpected CA Bundle ConfigMap OwnerReference;\n%s", diff)
+	}
+
+	desired, cm, err = desiredCABundleConfigMap(dns, false, &sourceConfigmap, destName)
+	if desired != false || cm != nil || err != nil {
+		t.Errorf("Unexpected error : %v", err)
+	}
+
+	var delTimestamp *metav1.Time
+	delTimestamp = &metav1.Time{
+		Time: time.Now(),
+	}
+	dns.DeletionTimestamp = delTimestamp
+
+	desired, cm, err = desiredCABundleConfigMap(dns, true, &sourceConfigmap, destName)
+	if desired != false || cm != nil || err != nil {
+		t.Errorf("Unexpected error : %v", err)
 	}
 }

--- a/pkg/operator/controller/controller_cabundle_configmap_test.go
+++ b/pkg/operator/controller/controller_cabundle_configmap_test.go
@@ -1,12 +1,13 @@
 package controller
 
 import (
+	"testing"
+	"time"
+
 	"github.com/google/go-cmp/cmp"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
-	"time"
 )
 
 func TestDesiredCABundleConfigmap(t *testing.T) {

--- a/pkg/operator/controller/controller_dns_configmap.go
+++ b/pkg/operator/controller/controller_dns_configmap.go
@@ -40,7 +40,7 @@ var corefileTemplate = template.Must(template.New("Corefile").Funcs(template.Fun
         {{- with $tls := .TransportConfig.TLS }}
         {{- with $serverName := $tls.ServerName }}
         tls_servername {{$serverName}}
-        tls {{- with $cm := $tls.CABundle.Name}} /etc/pki/{{$serverName}}-{{ index $.CABundleRevisionMap $cm }}/{{ $.CABundleFileName }}{{end}}
+        tls {{- with $.CABundleRevisionMap }}{{- with $cm := (index $.CABundleRevisionMap $tls.CABundle.Name) }} /etc/pki/{{$serverName}}-{{ $cm }}/{{ $.CABundleFileName }}{{end}}{{end}}
         {{- end}}
         {{- end}}
         policy {{ CoreDNSForwardingPolicy .Policy }}
@@ -76,7 +76,7 @@ var corefileTemplate = template.Must(template.New("Corefile").Funcs(template.Fun
         {{- with $tls := .TransportConfig.TLS }}
         {{- with $serverName := $tls.ServerName }}
         tls_servername {{$serverName}}
-        tls {{- with $cm := $tls.CABundle.Name}} /etc/pki/{{$serverName}}-{{ index $.CABundleRevisionMap $cm }}/{{ $.CABundleFileName }}{{end}}
+        tls {{- with $.CABundleRevisionMap }}{{- with $cm := (index $.CABundleRevisionMap $tls.CABundle.Name) }} /etc/pki/{{$serverName}}-{{ $cm }}/{{ $.CABundleFileName }}{{end}}{{end}}
         {{- end}}
         {{- end}}
         policy {{ CoreDNSForwardingPolicy .Policy }}

--- a/pkg/operator/controller/controller_dns_configmap_test.go
+++ b/pkg/operator/controller/controller_dns_configmap_test.go
@@ -828,6 +828,40 @@ func TestDesiredDNSConfigmapUpstreamResolvers(t *testing.T) {
 			},
 			expectedCoreFile: mustLoadTestFile(t, "upstreamresolvers_with_cabundle"),
 		},
+		{
+			name: "CR with upstreamResolvers using TLS defining a non-existing CA bundle should return a coreFile containing upstreams with TLS and no CA bundle",
+			dns: &operatorv1.DNS{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: DefaultDNSController,
+				},
+				Spec: operatorv1.DNSSpec{
+					UpstreamResolvers: operatorv1.UpstreamResolvers{
+						Upstreams: []operatorv1.Upstream{
+							{
+								Type:    operatorv1.NetworkResolverType,
+								Address: "9.8.7.6",
+							},
+							{
+								Type:    operatorv1.NetworkResolverType,
+								Address: "1001:AAAA:bbbb:cCcC::2222",
+								Port:    53,
+							},
+						},
+						Policy: operatorv1.RoundRobinForwardingPolicy,
+						TransportConfig: operatorv1.DNSTransportConfig{
+							Transport: operatorv1.TLSTransport,
+							TLS: &operatorv1.DNSOverTLSConfig{
+								ServerName: "example.com",
+								CABundle: v1.ConfigMapNameReference{
+									Name: "ca-bundle-config-2",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCoreFile: mustLoadTestFile(t, "tls_with_non_existing_cabundle"),
+		},
 	}
 
 	clusterDomain := "cluster.local"

--- a/pkg/operator/controller/controller_dns_daemonset_test.go
+++ b/pkg/operator/controller/controller_dns_daemonset_test.go
@@ -116,6 +116,22 @@ func TestDesiredDNSDaemonsetWithCABundleConfigMaps(t *testing.T) {
 					Name:  "bar.com",
 					Zones: []string{"bar.com"},
 				},
+				{
+					ForwardPlugin: operatorv1.ForwardPlugin{
+						TransportConfig: operatorv1.DNSTransportConfig{
+							Transport: operatorv1.TLSTransport,
+							TLS: &operatorv1.DNSOverTLSConfig{
+								ServerName: "dns.foo.com",
+								CABundle: v1.ConfigMapNameReference{
+									Name: "non_existing_caBundle",
+								},
+							},
+						},
+						Upstreams: []string{"3.3.3.3"},
+					},
+					Name:  "foobar.com",
+					Zones: []string{"foobar.com"},
+				},
 			},
 			UpstreamResolvers: operatorv1.UpstreamResolvers{
 				TransportConfig: operatorv1.DNSTransportConfig{

--- a/pkg/operator/controller/testdata/tls_with_non_existing_cabundle
+++ b/pkg/operator/controller/testdata/tls_with_non_existing_cabundle
@@ -1,0 +1,25 @@
+.:5353 {
+    bufsize 512
+    errors
+    log . {
+        class error
+    }
+    health {
+        lameduck 20s
+    }
+    ready
+    kubernetes cluster.local in-addr.arpa ip6.arpa {
+        pods insecure
+        fallthrough in-addr.arpa ip6.arpa
+    }
+    prometheus 127.0.0.1:9153
+    forward . tls://9.8.7.6 tls://[1001:AAAA:BBBB:CCCC::2222]:53 {
+        tls_servername example.com
+        tls
+        policy round_robin
+    }
+    cache 900 {
+        denial 9984 30
+    }
+    reload
+}

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -853,12 +853,12 @@ func TestDNSOverTLSToleratesMissingSourceCM(t *testing.T) {
 
 	dnsOperatorPods, err := getClusterDNSOperatorPods(cl)
 	if err != nil {
-		t.Fatalf("unable to get operator pods: %w", err)
+		t.Fatalf("unable to get operator pods: %v", err)
 	}
 
 	for _, dnsOperatorPod := range dnsOperatorPods.Items {
 		if err := lookForStringInPodLog(operatorcontroller.DefaultOperatorNamespace, dnsOperatorPod.Name, operatorcontroller.ContainerNameOfDNSOperator, missingCMLog, 30*time.Second); err != nil {
-			t.Fatalf("could not find pod logs %w", err)
+			t.Fatalf("could not find pod logs %v", err)
 		}
 	}
 

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -5,13 +5,7 @@ package e2e
 
 import (
 	"context"
-	"crypto/rand"
-	"crypto/rsa"
-	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
 	"fmt"
-	"math/big"
 	"reflect"
 	"strings"
 	"testing"
@@ -20,16 +14,13 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 
-	operatorclient "github.com/openshift/cluster-dns-operator/pkg/operator/client"
 	operatorcontroller "github.com/openshift/cluster-dns-operator/pkg/operator/controller"
 	statuscontroller "github.com/openshift/cluster-dns-operator/pkg/operator/controller/status"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -78,19 +69,6 @@ var (
 		{Type: operatorv1.OperatorStatusTypeDegraded, Status: operatorv1.ConditionFalse},
 	}
 )
-
-func getClient() (client.Client, error) {
-	// Get a kube client.
-	kubeConfig, err := config.GetConfig()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get kube config: %v", err)
-	}
-	kubeClient, err := operatorclient.NewClient(kubeConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create kube client: %v", err)
-	}
-	return kubeClient, nil
-}
 
 func TestOperatorAvailable(t *testing.T) {
 	cl, err := getClient()
@@ -858,10 +836,9 @@ func TestDNSOverTLSToleratesMissingSourceCM(t *testing.T) {
 
 	for _, dnsOperatorPod := range dnsOperatorPods.Items {
 		if err := lookForStringInPodLog(operatorcontroller.DefaultOperatorNamespace, dnsOperatorPod.Name, operatorcontroller.ContainerNameOfDNSOperator, missingCMLog, 30*time.Second); err != nil {
-			t.Fatalf("could not find pod logs %v", err)
+			t.Fatalf("could not find pod logs: %v", err)
 		}
 	}
-
 }
 
 func TestDNSLogging(t *testing.T) {
@@ -1139,145 +1116,4 @@ func TestDNSNodePlacement(t *testing.T) {
 	if len(podList.Items) == 0 {
 		t.Errorf("expected label selector matching 0 nodes to be ignored; found 0 dns pods")
 	}
-}
-
-// generateServerCA generates and returns a CA certificate and key.
-func generateServerCA() (*x509.Certificate, *rsa.PrivateKey, error) {
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	root := &x509.Certificate{
-		Subject:               pkix.Name{CommonName: "operator-e2e"},
-		SignatureAlgorithm:    x509.SHA256WithRSA,
-		NotBefore:             time.Now().Add(-24 * time.Hour),
-		NotAfter:              time.Now().Add(24 * time.Hour),
-		SerialNumber:          big.NewInt(1),
-		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
-		BasicConstraintsValid: true,
-		IsCA:                  true,
-		MaxPathLen:            0,
-		MaxPathLenZero:        true,
-	}
-
-	der, err := x509.CreateCertificate(rand.Reader, root, root, &key.PublicKey, key)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	certs, err := x509.ParseCertificates(der)
-	if err != nil {
-		return nil, nil, err
-	}
-	if len(certs) != 1 {
-		return nil, nil, fmt.Errorf("expected a single certificate from x509.ParseCertificates, got %d: %v", len(certs), certs)
-	}
-
-	return certs[0], key, nil
-}
-
-// generateServerCertificate generates and returns a client certificate and key
-// where the certificate is signed by the provided CA certificate.
-func generateServerCertificate(caCert *x509.Certificate, caKey *rsa.PrivateKey, cn string) (*x509.Certificate, *rsa.PrivateKey, error) {
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	template := &x509.Certificate{
-		Subject: pkix.Name{
-			CommonName:   cn,
-			Organization: []string{"OpenShift"},
-		},
-		SignatureAlgorithm:    x509.SHA256WithRSA,
-		NotBefore:             time.Now().Add(-24 * time.Hour),
-		NotAfter:              time.Now().Add(24 * time.Hour),
-		SerialNumber:          big.NewInt(1),
-		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		BasicConstraintsValid: true,
-		DNSNames:              []string{cn},
-	}
-
-	derBytes, err := x509.CreateCertificate(rand.Reader, template, caCert, &key.PublicKey, caKey)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	certs, err := x509.ParseCertificates(derBytes)
-	if err != nil {
-		return nil, nil, err
-	}
-	if len(certs) != 1 {
-		return nil, nil, fmt.Errorf("expected a single certificate from x509.ParseCertificates, got %d: %v", len(certs), certs)
-	}
-
-	return certs[0], key, nil
-}
-
-// encodeCert returns a PEM block encoding the given certificate.
-func encodeCert(cert *x509.Certificate) string {
-	return string(pem.EncodeToMemory(&pem.Block{
-		Type:  "CERTIFICATE",
-		Bytes: cert.Raw,
-	}))
-}
-
-// encodeKey returns a PEM block encoding the given key.
-func encodeKey(key *rsa.PrivateKey) string {
-	return string(pem.EncodeToMemory(&pem.Block{
-		Type:  "RSA PRIVATE KEY",
-		Bytes: x509.MarshalPKCS1PrivateKey(key),
-	}))
-}
-
-func upstreamTLSPod(name, ns, image string, configMap *corev1.ConfigMap) *corev1.Pod {
-	coreContainer := upstreamContainer(name, image)
-	volumeName := configMap.Name
-
-	items := []corev1.KeyToPath{}
-	for k := range configMap.Data {
-		items = append(items, corev1.KeyToPath{Key: k, Path: k})
-	}
-	volume := corev1.Volume{
-		Name: "config-volume",
-		VolumeSource: corev1.VolumeSource{
-			ConfigMap: &corev1.ConfigMapVolumeSource{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: volumeName,
-				},
-				Items: items,
-			},
-		},
-	}
-	return &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: ns,
-			Labels:    map[string]string{"test": "upstream-tls"},
-		},
-		Spec: corev1.PodSpec{
-			Volumes:    []corev1.Volume{volume},
-			Containers: []corev1.Container{coreContainer},
-		},
-	}
-}
-
-func getClusterDNSOperatorPods(cl client.Client) (*corev1.PodList, error) {
-	dnsOperatorDeployment := &appsv1.Deployment{}
-	if err := cl.Get(context.TODO(), operatorcontroller.DefaultDNSOperatorDeploymentName(), dnsOperatorDeployment); err != nil {
-		return nil, fmt.Errorf("failed to get deployment %s/%s: %v", dnsOperatorDeployment.Namespace, dnsOperatorDeployment.Name, err)
-	}
-	operatorSelector, err := metav1.LabelSelectorAsSelector(dnsOperatorDeployment.Spec.Selector)
-	if err != nil {
-		return nil, fmt.Errorf("daemonset %s/%s has invalid spec.selector: %v", dnsOperatorDeployment.Namespace, dnsOperatorDeployment.Name, err)
-	}
-
-	dnsOperatorPods := &corev1.PodList{}
-	if err := cl.List(context.TODO(), dnsOperatorPods, client.MatchingLabelsSelector{Selector: operatorSelector}, client.InNamespace(dnsOperatorDeployment.Namespace)); err != nil {
-		return nil, fmt.Errorf("failed to list pods for dns deployment %s/%s: %v", dnsOperatorDeployment.Namespace, dnsOperatorDeployment.Name, err)
-	}
-
-	return dnsOperatorPods, nil
 }

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -5,9 +5,16 @@ package e2e
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
+	"math/big"
 	"os/exec"
 	"reflect"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"strings"
 	"testing"
 	"time"
@@ -15,12 +22,14 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 
-	"github.com/openshift/cluster-dns-operator/pkg/operator/controller"
+	operatorclient "github.com/openshift/cluster-dns-operator/pkg/operator/client"
+	operatorcontroller "github.com/openshift/cluster-dns-operator/pkg/operator/controller"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -295,7 +304,7 @@ func buildContainer(name, image string, cmd []string) corev1.Container {
 func waitForClusterOperatorConditions(t *testing.T, cl client.Client, timeout time.Duration, conditions ...configv1.ClusterOperatorStatusCondition) error {
 	return wait.PollImmediate(1*time.Second, timeout, func() (bool, error) {
 		co := &configv1.ClusterOperator{}
-		coName := controller.DNSClusterOperatorName()
+		coName := operatorcontroller.DNSClusterOperatorName()
 		if err := cl.Get(context.TODO(), coName, co); err != nil {
 			t.Logf("failed to get DNS cluster operator %s: %v", coName.Name, err)
 			return false, nil
@@ -355,4 +364,158 @@ func conditionsMatchExpected(expected, actual map[string]string) bool {
 		}
 	}
 	return reflect.DeepEqual(expected, filtered)
+}
+
+func getClusterDNSOperatorPods(cl client.Client) (*corev1.PodList, error) {
+	dnsOperatorDeployment := &appsv1.Deployment{}
+	if err := cl.Get(context.TODO(), operatorcontroller.DefaultDNSOperatorDeploymentName(), dnsOperatorDeployment); err != nil {
+		return nil, fmt.Errorf("failed to get deployment %s/%s: %v", dnsOperatorDeployment.Namespace, dnsOperatorDeployment.Name, err)
+	}
+	operatorSelector, err := metav1.LabelSelectorAsSelector(dnsOperatorDeployment.Spec.Selector)
+	if err != nil {
+		return nil, fmt.Errorf("daemonset %s/%s has invalid spec.selector: %v", dnsOperatorDeployment.Namespace, dnsOperatorDeployment.Name, err)
+	}
+
+	dnsOperatorPods := &corev1.PodList{}
+	if err := cl.List(context.TODO(), dnsOperatorPods, client.MatchingLabelsSelector{Selector: operatorSelector}, client.InNamespace(dnsOperatorDeployment.Namespace)); err != nil {
+		return nil, fmt.Errorf("failed to list pods for dns deployment %s/%s: %v", dnsOperatorDeployment.Namespace, dnsOperatorDeployment.Name, err)
+	}
+
+	return dnsOperatorPods, nil
+}
+
+func upstreamTLSPod(name, ns, image string, configMap *corev1.ConfigMap) *corev1.Pod {
+	coreContainer := upstreamContainer(name, image)
+	volumeName := configMap.Name
+
+	items := []corev1.KeyToPath{}
+	for k := range configMap.Data {
+		items = append(items, corev1.KeyToPath{Key: k, Path: k})
+	}
+	volume := corev1.Volume{
+		Name: "config-volume",
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: volumeName,
+				},
+				Items: items,
+			},
+		},
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels:    map[string]string{"test": "upstream-tls"},
+		},
+		Spec: corev1.PodSpec{
+			Volumes:    []corev1.Volume{volume},
+			Containers: []corev1.Container{coreContainer},
+		},
+	}
+}
+
+func getClient() (client.Client, error) {
+	// Get a kube client.
+	kubeConfig, err := config.GetConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get kube config: %v", err)
+	}
+	kubeClient, err := operatorclient.NewClient(kubeConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kube client: %v", err)
+	}
+	return kubeClient, nil
+}
+
+// encodeCert returns a PEM block encoding the given certificate.
+func encodeCert(cert *x509.Certificate) string {
+	return string(pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: cert.Raw,
+	}))
+}
+
+// encodeKey returns a PEM block encoding the given key.
+func encodeKey(key *rsa.PrivateKey) string {
+	return string(pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	}))
+}
+
+// generateServerCA generates and returns a CA certificate and key.
+func generateServerCA() (*x509.Certificate, *rsa.PrivateKey, error) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := &x509.Certificate{
+		Subject:               pkix.Name{CommonName: "operator-e2e"},
+		SignatureAlgorithm:    x509.SHA256WithRSA,
+		NotBefore:             time.Now().Add(-24 * time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		SerialNumber:          big.NewInt(1),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		MaxPathLen:            0,
+		MaxPathLenZero:        true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, root, root, &key.PublicKey, key)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certs, err := x509.ParseCertificates(der)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(certs) != 1 {
+		return nil, nil, fmt.Errorf("expected a single certificate from x509.ParseCertificates, got %d: %v", len(certs), certs)
+	}
+
+	return certs[0], key, nil
+}
+
+// generateServerCertificate generates and returns a client certificate and key
+// where the certificate is signed by the provided CA certificate.
+func generateServerCertificate(caCert *x509.Certificate, caKey *rsa.PrivateKey, cn string) (*x509.Certificate, *rsa.PrivateKey, error) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	template := &x509.Certificate{
+		Subject: pkix.Name{
+			CommonName:   cn,
+			Organization: []string{"OpenShift"},
+		},
+		SignatureAlgorithm:    x509.SHA256WithRSA,
+		NotBefore:             time.Now().Add(-24 * time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		SerialNumber:          big.NewInt(1),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              []string{cn},
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, template, caCert, &key.PublicKey, caKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certs, err := x509.ParseCertificates(derBytes)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(certs) != 1 {
+		return nil, nil, fmt.Errorf("expected a single certificate from x509.ParseCertificates, got %d: %v", len(certs), certs)
+	}
+
+	return certs[0], key, nil
 }


### PR DESCRIPTION
* Fixes a nil pointer error that was crashing the operator when configuring DNS-over-TLS with a configmap that does not exist.
* Simplifies some of the configmap management logic.
* Adds a corresponding e2e test.