### PR TITLE
Bug 2095941: topology aware hints to prefer to keep dns traffic within a zone

### DIFF
--- a/pkg/operator/controller/controller_dns_service_test.go
+++ b/pkg/operator/controller/controller_dns_service_test.go
@@ -121,6 +121,15 @@ func TestDNSServiceChanged(t *testing.T) {
 			},
 			expect: false,
 		},
+		{
+			description: "if service.kubernetes.io/topology-aware-hints annotation is set",
+			mutate: func(service *corev1.Service) {
+				service.ObjectMeta.Annotations = map[string]string{
+					"service.kubernetes.io/topology-aware-hints": "auto",
+				}
+			},
+			expect: true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Currently DNS traffic in openshift can go to any random pod on any host in any zone. Traffic should at a minimum be prefered to stay within a zone to prevent latency and reduce failure points in a given dns request. This requiresOpenshift 4.11 or TopologyAwareHints feature gate to be enabled.