### PR TITLE
DPP-10859: Update Bugzilla links to "Networking" component

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,6 @@
 contact_links:
 - name: File a Bugzilla report
-  url: https://bugzilla.redhat.com/enter_bug.cgi?product=OpenShift%20Container%20Platform&component=DNS
+  url: https://bugzilla.redhat.com/enter_bug.cgi?product=OpenShift%20Container%20Platform&component=Networking&sub_component=DNS
   about: Please use Bugzilla to report issues.
 - name: DNS Operator in OpenShift Container Platform
   url: https://docs.openshift.com/container-platform/latest/networking/dns-operator.html

--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ See [HACKING.md](HACKING.md) for development topics.
 
 ## Reporting issues
 
-Bugs are tracked in [Bugzilla](https://bugzilla.redhat.com/enter_bug.cgi?product=OpenShift%20Container%20Platform&component=DNS).
+Bugs are tracked in [Bugzilla](https://bugzilla.redhat.com/enter_bug.cgi?product=OpenShift%20Container%20Platform&component=Networking&sub_component=DNS).


### PR DESCRIPTION
Update Bugzilla links that reference the "DNS" component to instead use the "Networking" component and "DNS" subcomponent.

* `.github/ISSUE_TEMPLATE/config.yml`:
* `README.md`: Update Bugzilla links.