### PR TITLE
OCPBUGS-360: Pod security policy change breaks DNS forwarding e2e tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	k8s.io/apimachinery v0.24.1
 	k8s.io/client-go v0.24.1
 	k8s.io/kubectl v0.24.1
+	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
 	sigs.k8s.io/controller-runtime v0.12.1
 )
 
@@ -65,7 +66,6 @@ require (
 	k8s.io/component-base v0.24.1 // indirect
 	k8s.io/klog/v2 v2.60.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42 // indirect
-	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -506,7 +506,7 @@ func TestDNSOverTLSForwarding(t *testing.T) {
 	// Create a separate namespace for the upstream resolver. Deleting this namespace will clean up the resources created.
 	tlsUpstreamNamespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: tlsUpstreamName,
+			Name: "openshift-testdnsovertls",
 		},
 	}
 	if err := cl.Create(context.TODO(), tlsUpstreamNamespace); err != nil {

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -33,6 +33,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
+
+	"k8s.io/utils/pointer"
 )
 
 // lookForStringInPodExec looks for expectedString in the output of command
@@ -183,6 +185,7 @@ func upstreamContainer(container, image string) corev1.Container {
 		ReadOnly:  true,
 		MountPath: "/etc/coredns",
 	}
+
 	return corev1.Container{
 		Name:           container,
 		Image:          image,
@@ -192,6 +195,16 @@ func upstreamContainer(container, image string) corev1.Container {
 		VolumeMounts:   []corev1.VolumeMount{configVolume},
 		LivenessProbe:  healthProbe,
 		ReadinessProbe: healthProbe,
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: pointer.Bool(false),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+			},
+			RunAsNonRoot: pointer.Bool(false),
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeRuntimeDefault,
+			},
+		},
 	}
 }
 

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -400,6 +400,7 @@ func getClusterDNSOperatorPods(cl client.Client) (*corev1.PodList, error) {
 func upstreamTLSPod(name, ns, image string, configMap *corev1.ConfigMap) *corev1.Pod {
 	coreContainer := upstreamContainer(name, image)
 	volumeName := configMap.Name
+	volumeMode := int32(420)
 
 	items := []corev1.KeyToPath{}
 	for k := range configMap.Data {
@@ -412,7 +413,8 @@ func upstreamTLSPod(name, ns, image string, configMap *corev1.ConfigMap) *corev1
 				LocalObjectReference: corev1.LocalObjectReference{
 					Name: volumeName,
 				},
-				Items: items,
+				Items:       items,
+				DefaultMode: &volumeMode,
 			},
 		},
 	}


### PR DESCRIPTION
This fixes the e2e breakage introduced with the recent adjustment of the default security policy.

* Adds a `SecurityContext` configuration to `upstreamContainer()` as that's used by both `TestDNSForwarding` and `TestDNSOverTLSForwarding`. The configuration is standard with one exception; `RunAsNonRoot: false` is needed because we're using `cluster-dns-operator`'s CoreDNS image which runs as root in the container.
* Switches the dns-over-tls test namespace to `openshift-testdnsovertls` as a workaround to the pod security autolabeling.
* Adds a volume mode to `upstreamTLSPod()` to match `upstreamPod()` as the lack of the volume mode seemed to stop the test pods from starting.