### PR TITLE
NE-1066: Enable the chaos plugin for CoreDNS in order to expose CoreDNS metadata

### DIFF
--- a/pkg/operator/controller/controller_dns_configmap.go
+++ b/pkg/operator/controller/controller_dns_configmap.go
@@ -87,6 +87,9 @@ var corefileTemplate = template.Must(template.New("Corefile").Funcs(template.Fun
     }
     reload
 }
+hostname.bind:5353 {
+    chaos
+}
 `))
 
 // ensureDNSConfigMap ensures that a configmap exists for a given DNS.

--- a/pkg/operator/controller/testdata/1ipv6_and_policy
+++ b/pkg/operator/controller/testdata/1ipv6_and_policy
@@ -36,3 +36,6 @@ foo.com:5353 {
     }
     reload
 }
+hostname.bind:5353 {
+    chaos
+}

--- a/pkg/operator/controller/testdata/1ns_and_policy
+++ b/pkg/operator/controller/testdata/1ns_and_policy
@@ -36,3 +36,6 @@ foo.com:5353 {
     }
     reload
 }
+hostname.bind:5353 {
+    chaos
+}

--- a/pkg/operator/controller/testdata/1ns_no_policy
+++ b/pkg/operator/controller/testdata/1ns_no_policy
@@ -36,3 +36,6 @@ foo.com:5353 {
     }
     reload
 }
+hostname.bind:5353 {
+    chaos
+}

--- a/pkg/operator/controller/testdata/1sysresconf
+++ b/pkg/operator/controller/testdata/1sysresconf
@@ -36,3 +36,6 @@ foo.com:5353 {
     }
     reload
 }
+hostname.bind:5353 {
+    chaos
+}

--- a/pkg/operator/controller/testdata/5upstreams
+++ b/pkg/operator/controller/testdata/5upstreams
@@ -36,3 +36,6 @@ foo.com:5353 {
     }
     reload
 }
+hostname.bind:5353 {
+    chaos
+}

--- a/pkg/operator/controller/testdata/debug_loglevel
+++ b/pkg/operator/controller/testdata/debug_loglevel
@@ -36,3 +36,6 @@ foo.com:5353 {
     }
     reload
 }
+hostname.bind:5353 {
+    chaos
+}

--- a/pkg/operator/controller/testdata/default_corefile
+++ b/pkg/operator/controller/testdata/default_corefile
@@ -81,3 +81,6 @@ buzz.com:5353 example.buzz.com:5353 {
     }
     reload
 }
+hostname.bind:5353 {
+    chaos
+}

--- a/pkg/operator/controller/testdata/duplicate_upstreams
+++ b/pkg/operator/controller/testdata/duplicate_upstreams
@@ -36,3 +36,6 @@ foo.com:5353 {
     }
     reload
 }
+hostname.bind:5353 {
+    chaos
+}

--- a/pkg/operator/controller/testdata/empty_upstreams_array
+++ b/pkg/operator/controller/testdata/empty_upstreams_array
@@ -36,3 +36,6 @@ foo.com:5353 {
     }
     reload
 }
+hostname.bind:5353 {
+    chaos
+}

--- a/pkg/operator/controller/testdata/forwardplugin_tls
+++ b/pkg/operator/controller/testdata/forwardplugin_tls
@@ -55,3 +55,6 @@ bar.com:5353 {
     }
     reload
 }
+hostname.bind:5353 {
+    chaos
+}

--- a/pkg/operator/controller/testdata/just_policy
+++ b/pkg/operator/controller/testdata/just_policy
@@ -36,3 +36,6 @@ foo.com:5353 {
     }
     reload
 }
+hostname.bind:5353 {
+    chaos
+}

--- a/pkg/operator/controller/testdata/mult_upstreamresolvers
+++ b/pkg/operator/controller/testdata/mult_upstreamresolvers
@@ -36,3 +36,6 @@ foo.com:5353 {
     }
     reload
 }
+hostname.bind:5353 {
+    chaos
+}

--- a/pkg/operator/controller/testdata/normal_loglevel
+++ b/pkg/operator/controller/testdata/normal_loglevel
@@ -36,3 +36,6 @@ foo.com:5353 {
     }
     reload
 }
+hostname.bind:5353 {
+    chaos
+}

--- a/pkg/operator/controller/testdata/tls_with_non_existing_cabundle
+++ b/pkg/operator/controller/testdata/tls_with_non_existing_cabundle
@@ -23,3 +23,6 @@
     }
     reload
 }
+hostname.bind:5353 {
+    chaos
+}

--- a/pkg/operator/controller/testdata/trace_loglevel
+++ b/pkg/operator/controller/testdata/trace_loglevel
@@ -36,3 +36,6 @@ foo.com:5353 {
     }
     reload
 }
+hostname.bind:5353 {
+    chaos
+}

--- a/pkg/operator/controller/testdata/upstreamresolvers_with_cabundle
+++ b/pkg/operator/controller/testdata/upstreamresolvers_with_cabundle
@@ -23,3 +23,6 @@
     }
     reload
 }
+hostname.bind:5353 {
+    chaos
+}

--- a/pkg/operator/controller/testdata/upstreams_type_empty
+++ b/pkg/operator/controller/testdata/upstreams_type_empty
@@ -36,3 +36,6 @@ foo.com:5353 {
     }
     reload
 }
+hostname.bind:5353 {
+    chaos
+}

--- a/pkg/operator/controller/testdata/without_upstreamresolvers
+++ b/pkg/operator/controller/testdata/without_upstreamresolvers
@@ -36,3 +36,6 @@ foo.com:5353 {
     }
     reload
 }
+hostname.bind:5353 {
+    chaos
+}


### PR DESCRIPTION
Turns on the `chaos` CoreDNS plugin (https://coredns.io/plugins/chaos/) that exposes some metadata that can help debugging in the future.

The regression https://issues.redhat.com/browse/OCPBUGS-488 found in 4.10 has exposed a CI test gap in local DNS endpoint preference and this plugin would allow a new CI tests to determine what CoreDNS pod is replying to a query so we can determine it is indeed the local DNS endpoint.