### PR TITLE
OCPBUGS-753: keep dns-default annotations intact

### DIFF
--- a/pkg/operator/controller/controller_dns_daemonset_test.go
+++ b/pkg/operator/controller/controller_dns_daemonset_test.go
@@ -29,6 +29,7 @@ func TestDesiredDNSDaemonset(t *testing.T) {
 		// Validate the daemonset
 		expectedPodAnnotations := map[string]string{
 			"cluster-autoscaler.kubernetes.io/enable-ds-eviction": "true",
+			"target.workload.openshift.io/management":             "{\"effect\": \"PreferredDuringScheduling\"}",
 		}
 		actualPodAnnotations := ds.Spec.Template.Annotations
 		expectedPodLabels := map[string]string{
@@ -490,12 +491,36 @@ func TestDaemonsetConfigChanged(t *testing.T) {
 			expect: false,
 		},
 		{
-			description: "if the enable-ds-eviction annotation is added",
+			description: "if the enable-ds-eviction annotation is changed",
 			mutate: func(daemonset *appsv1.DaemonSet) {
 				if daemonset.Spec.Template.Annotations == nil {
 					daemonset.Spec.Template.Annotations = map[string]string{}
 				}
-				daemonset.Spec.Template.Annotations["cluster-autoscaler.kubernetes.io/enable-ds-eviction"] = "true"
+				daemonset.Spec.Template.Annotations["cluster-autoscaler.kubernetes.io/enable-ds-eviction"] = ""
+			},
+			expect: true,
+		},
+		{
+			description: "if the target workload annotation is changed",
+			mutate: func(daemonset *appsv1.DaemonSet) {
+				if daemonset.Spec.Template.Annotations == nil {
+					daemonset.Spec.Template.Annotations = map[string]string{}
+				}
+				daemonset.Spec.Template.Annotations["target.workload.openshift.io/management"] = ""
+			},
+			expect: true,
+		},
+		{
+			description: "if the enable-ds-eviction annotation is deleted",
+			mutate: func(daemonset *appsv1.DaemonSet) {
+				delete(daemonset.Spec.Template.Annotations, "cluster-autoscaler.kubernetes.io/enable-ds-eviction")
+			},
+			expect: true,
+		},
+		{
+			description: "if the target workload annotation is deleted",
+			mutate: func(daemonset *appsv1.DaemonSet) {
+				delete(daemonset.Spec.Template.Annotations, "target.workload.openshift.io/management")
 			},
 			expect: true,
 		},
@@ -511,6 +536,12 @@ func TestDaemonsetConfigChanged(t *testing.T) {
 			},
 			Spec: appsv1.DaemonSetSpec{
 				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"cluster-autoscaler.kubernetes.io/enable-ds-eviction": "true",
+							"target.workload.openshift.io/management":             "{\"effect\": \"PreferredDuringScheduling\"}",
+						},
+					},
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
 							{

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -267,6 +267,80 @@ func TestOperatorRecreatesItsClusterOperator(t *testing.T) {
 	}
 }
 
+// TestOperatorRecreatesItsManagedAnnotations verifies that the DNS operator
+// recreates its managed annotations if they are deleted.
+func TestOperatorRecreatesItsManagedAnnotations(t *testing.T) {
+	cl, err := getClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	enableDaemonSetEvictionAnnotationKey := "cluster-autoscaler.kubernetes.io/enable-ds-eviction"
+	targetWorkloadManagementAnnotationKey := "target.workload.openshift.io/management"
+	var evict, target string
+	var ok bool
+
+	defaultDNS := &operatorv1.DNS{}
+	err = wait.PollImmediate(1*time.Second, 5*time.Minute, func() (bool, error) {
+		if err := cl.Get(context.TODO(), types.NamespacedName{Name: operatorcontroller.DefaultDNSController}, defaultDNS); err != nil {
+			t.Logf("failed to get dns %q: %v", operatorcontroller.DefaultDNSController, err)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("failed to get dns %q: %v", operatorcontroller.DefaultDNSController, err)
+	}
+
+	namespacedName := operatorcontroller.DNSDaemonSetName(defaultDNS)
+	err = wait.PollImmediate(1*time.Second, 5*time.Minute, func() (bool, error) {
+		dnsDaemonSet := &appsv1.DaemonSet{}
+		if err := cl.Get(context.TODO(), namespacedName, dnsDaemonSet); err != nil {
+			t.Logf("failed to get daemonset %s: %v", namespacedName, err)
+			return false, nil
+		}
+		// Verify that the annotations are there to begin with
+		if evict, ok = dnsDaemonSet.Spec.Template.Annotations[enableDaemonSetEvictionAnnotationKey]; !ok {
+			t.Errorf("inconsistent daemonset %s: missing annotation: %s", namespacedName, enableDaemonSetEvictionAnnotationKey)
+		}
+		if target, ok = dnsDaemonSet.Spec.Template.Annotations[targetWorkloadManagementAnnotationKey]; !ok {
+			t.Errorf("inconsistent daemonset %s: missing annotation: %s", namespacedName, targetWorkloadManagementAnnotationKey)
+		}
+		// Change the annotations
+		dnsDaemonSet.Spec.Template.Annotations[enableDaemonSetEvictionAnnotationKey] = ""
+		dnsDaemonSet.Spec.Template.Annotations[targetWorkloadManagementAnnotationKey] = ""
+
+		if err := cl.Update(context.TODO(), dnsDaemonSet); err != nil {
+			t.Logf("failed to update daemonset %s: %v", namespacedName, err)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		t.Errorf("failed to update daemonset %s: %v", namespacedName, err)
+	}
+
+	err = wait.PollImmediate(1*time.Second, 5*time.Minute, func() (bool, error) {
+		dnsDaemonSet := &appsv1.DaemonSet{}
+		if err := cl.Get(context.TODO(), namespacedName, dnsDaemonSet); err != nil {
+			t.Logf("failed to get daemonset %s: %v", namespacedName, err)
+			return false, nil
+		}
+		for k, v := range dnsDaemonSet.Spec.Template.Annotations {
+			if k == enableDaemonSetEvictionAnnotationKey && v != evict {
+				return false, nil
+			} else if k == targetWorkloadManagementAnnotationKey && v != target {
+				return false, nil
+			}
+		}
+		t.Logf("observed correct managed annotation values on daemonset %s", namespacedName)
+		return true, nil
+	})
+	if err != nil {
+		t.Errorf("failed to observe correct managed annotation values on daemonset %s", namespacedName)
+	}
+
+}
+
 func TestDNSForwarding(t *testing.T) {
 	cl, err := getClient()
 	if err != nil {


### PR DESCRIPTION
When adding the enable DaemonSet eviction annotation `cluster-autoscaler.kubernetes.io/enable-ds-eviction`, do not overwrite other annotations.  Fix missing managed annotation - `target.workload.openshift.io/management`. Fix unit tests. Add e2e test.

modified:   pkg/operator/controller/controller_dns_daemonset.go
modified:   pkg/operator/controller/controller_dns_daemonset_test.go
modified: test/e2e/operator_test.go

