### PR TITLE
OCPBUGS-1549: Reconcile the DNS namespace

### DIFF
--- a/pkg/operator/controller/controller_test.go
+++ b/pkg/operator/controller/controller_test.go
@@ -1,0 +1,56 @@
+package controller
+
+import (
+	"github.com/openshift/cluster-dns-operator/pkg/manifests"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestDNSNamespaceLabelsChanged(t *testing.T) {
+	originalNamespace := manifests.DNSNamespace()
+
+	testCases := []struct {
+		description    string
+		mutate         func(namespace *corev1.Namespace)
+		changeExpected bool
+	}{
+		{
+			description:    "if nothing changes",
+			mutate:         func(_ *corev1.Namespace) {},
+			changeExpected: false,
+		},
+		{
+			description: "if arbitrary label added",
+			mutate: func(namespace *corev1.Namespace) {
+				if namespace.Labels == nil {
+					namespace.Labels = map[string]string{}
+				}
+				namespace.Labels["foo"] = "bar"
+			},
+			changeExpected: false,
+		},
+		{
+			description: "if required label changes",
+			mutate: func(namespace *corev1.Namespace) {
+				if namespace.Labels == nil {
+					namespace.Labels = map[string]string{}
+				}
+				namespace.Labels[namespacePodSecurityEnforceLabel] = ""
+			},
+			changeExpected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		mutated := originalNamespace.DeepCopy()
+		tc.mutate(mutated)
+		if changed, updated := namespaceLabelsChanged(originalNamespace, mutated); changed != tc.changeExpected {
+			t.Errorf("%s, expect namespaceLabelsChanged to be %t, got %t", tc.description, tc.changeExpected, changed)
+		} else if changed {
+			if changedAgain, _ := namespaceLabelsChanged(updated, mutated); changedAgain {
+				t.Errorf("%s, namespaceLabelsChanged does not behave as a fixed point function", tc.description)
+			}
+		}
+	}
+}

--- a/pkg/operator/controller/names.go
+++ b/pkg/operator/controller/names.go
@@ -63,6 +63,13 @@ func DefaultDNSNamespaceName() types.NamespacedName {
 	}
 }
 
+// DefaultDNSOperandNamespaceName returns the namespaced name of the default DNS operand resource.
+func DefaultDNSOperandNamespaceName() types.NamespacedName {
+	return types.NamespacedName{
+		Name: DefaultOperandNamespace,
+	}
+}
+
 // DNSDaemonSetName returns the namespaced name for the dns daemonset.
 func DNSDaemonSetName(dns *operatorv1.DNS) types.NamespacedName {
 	return types.NamespacedName{


### PR DESCRIPTION
The DNS namespace manifest has been updated, and changes need to be applied during the controller reconcile.  Add all the required labels to a set and compare the existing namespace labels to this set.  If they don't match, change them and update the namespace.  Add a unit test.

NamespaceRunLevelLabel           = "openshift.io/run-level"    
NamespaceClusterMonitoringLabel  = "openshift.io/cluster-monitoring" 
NamespacePodSecurityEnforceLabel = "pod-security.kubernetes.io/enforce"
NamespacePodSecurityAuditLabel   = "pod-security.kubernetes.io/audit" 
NamespacePodSecurityWarnLabel    = "pod-security.kubernetes.io/warn"   
