### PR TITLE
Updating ose-cluster-dns-operator images to be consistent with ART, and generate bindata

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.18-openshift-4.11
+  tag: rhel-8-release-golang-1.19-openshift-4.12

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.11 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 AS builder
 WORKDIR /dns-operator
 COPY . .
 RUN make build
 
-FROM registry.ci.openshift.org/ocp/4.11:base
+FROM registry.ci.openshift.org/ocp/4.12:base
 COPY --from=builder /dns-operator/dns-operator /usr/bin/
 COPY manifests /manifests
 RUN useradd dns-operator

--- a/pkg/manifests/bindata.go
+++ b/pkg/manifests/bindata.go
@@ -440,11 +440,13 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//     data/
-//       foo.txt
-//       img/
-//         a.png
-//         b.png
+//
+//	data/
+//	  foo.txt
+//	  img/
+//	    a.png
+//	    b.png
+//
 // then AssetDir("data") would return []string{"foo.txt", "img"},
 // AssetDir("data/img") would return []string{"a.png", "b.png"},
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error, and


### PR DESCRIPTION
Reconciling with https://github.com/openshift/ocp-build-data/tree/b44f15ec9e84d1831eac81f8c757b3bed985dbeb/images/ose-cluster-dns-operator.yml

This PR is based on #331 but additionally includes changes to the formatting of `pkg/manifests/bindata.go` that result from using the updated Go 1.19 builder image.  Including these changes is necessary in order for the verify job to pass.  