### PR TITLE
[release-4.10] OCPBUGS-2602: Allow autoscaler to evict DNS pods

### DIFF
--- a/pkg/operator/controller/controller_dns_daemonset.go
+++ b/pkg/operator/controller/controller_dns_daemonset.go
@@ -18,8 +18,22 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// enableDaemonSetEvictionAnnotationKey is the annotation key for the
+	// annotation that enables eviction of a daemonset by the cluster
+	// autoscaler.
+	enableDaemonSetEvictionAnnotationKey = "cluster-autoscaler.kubernetes.io/enable-ds-eviction"
+)
+
+var (
+	// managedDNSDaemonSetAnnotations is a set of annotation keys for
+	// annotations that the operator manages for the DNS daemonset.
+	managedDNSDaemonSetAnnotations = sets.NewString(enableDaemonSetEvictionAnnotationKey)
 )
 
 // ensureDNSDaemonSet ensures the dns daemonset exists for a given dns.
@@ -78,10 +92,15 @@ func desiredDNSDaemonSet(dns *operatorv1.DNS, coreDNSImage, kubeRBACProxyImage s
 		manifests.OwningDNSLabel: DNSDaemonSetLabel(dns),
 	}
 
+	// Enable eviction when cluster-autoscaler removes a node.  This ensures
+	// that the cluster DNS service stops forwarding queries to the DNS pod
+	// *before* the hosting node shuts down.
+	daemonset.Spec.Template.Annotations = map[string]string{
+		enableDaemonSetEvictionAnnotationKey: "true",
+	}
 	// Ensure the daemonset adopts only its own pods.
 	daemonset.Spec.Selector = DNSDaemonSetPodSelector(dns)
 	daemonset.Spec.Template.Labels = daemonset.Spec.Selector.MatchLabels
-
 	daemonset.Spec.Template.Spec.NodeSelector = nodeSelectorForDNS(dns)
 	daemonset.Spec.Template.Spec.Tolerations = tolerationsForDNS(dns)
 
@@ -314,6 +333,20 @@ func daemonsetConfigChanged(current, expected *appsv1.DaemonSet) (bool, *appsv1.
 	}
 	// TODO: Also check Env?
 
+	if updated.Spec.Template.Annotations == nil {
+		updated.Spec.Template.Annotations = map[string]string{}
+	}
+	for k := range managedDNSDaemonSetAnnotations {
+		currentVal, have := current.Spec.Template.Annotations[k]
+		expectedVal, want := expected.Spec.Template.Annotations[k]
+		if want && (!have || currentVal != expectedVal) {
+			updated.Spec.Template.Annotations[k] = expected.Spec.Template.Annotations[k]
+			changed = true
+		} else if have && !want {
+			delete(updated.Spec.Template.Annotations, k)
+			changed = true
+		}
+	}
 	if !cmp.Equal(current.Spec.Template.Spec.NodeSelector, expected.Spec.Template.Spec.NodeSelector, cmpopts.EquateEmpty()) {
 		updated.Spec.Template.Spec.NodeSelector = expected.Spec.Template.Spec.NodeSelector
 		changed = true

--- a/pkg/operator/controller/controller_dns_daemonset.go
+++ b/pkg/operator/controller/controller_dns_daemonset.go
@@ -27,13 +27,14 @@ const (
 	// enableDaemonSetEvictionAnnotationKey is the annotation key for the
 	// annotation that enables eviction of a daemonset by the cluster
 	// autoscaler.
-	enableDaemonSetEvictionAnnotationKey = "cluster-autoscaler.kubernetes.io/enable-ds-eviction"
+	enableDaemonSetEvictionAnnotationKey  = "cluster-autoscaler.kubernetes.io/enable-ds-eviction"
+	targetWorkloadManagementAnnotationKey = "target.workload.openshift.io/management"
 )
 
 var (
 	// managedDNSDaemonSetAnnotations is a set of annotation keys for
 	// annotations that the operator manages for the DNS daemonset.
-	managedDNSDaemonSetAnnotations = sets.NewString(enableDaemonSetEvictionAnnotationKey)
+	managedDNSDaemonSetAnnotations = sets.NewString(enableDaemonSetEvictionAnnotationKey, targetWorkloadManagementAnnotationKey)
 )
 
 // ensureDNSDaemonSet ensures the dns daemonset exists for a given dns.
@@ -95,9 +96,11 @@ func desiredDNSDaemonSet(dns *operatorv1.DNS, coreDNSImage, kubeRBACProxyImage s
 	// Enable eviction when cluster-autoscaler removes a node.  This ensures
 	// that the cluster DNS service stops forwarding queries to the DNS pod
 	// *before* the hosting node shuts down.
-	daemonset.Spec.Template.Annotations = map[string]string{
-		enableDaemonSetEvictionAnnotationKey: "true",
+	if daemonset.Spec.Template.Annotations == nil {
+		daemonset.Spec.Template.Annotations = map[string]string{}
 	}
+	daemonset.Spec.Template.Annotations[enableDaemonSetEvictionAnnotationKey] = "true"
+
 	// Ensure the daemonset adopts only its own pods.
 	daemonset.Spec.Selector = DNSDaemonSetPodSelector(dns)
 	daemonset.Spec.Template.Labels = daemonset.Spec.Selector.MatchLabels
@@ -347,6 +350,7 @@ func daemonsetConfigChanged(current, expected *appsv1.DaemonSet) (bool, *appsv1.
 			changed = true
 		}
 	}
+
 	if !cmp.Equal(current.Spec.Template.Spec.NodeSelector, expected.Spec.Template.Spec.NodeSelector, cmpopts.EquateEmpty()) {
 		updated.Spec.Template.Spec.NodeSelector = expected.Spec.Template.Spec.NodeSelector
 		changed = true


### PR DESCRIPTION
#### `desiredDNSDaemonSet`: Allow autoscaler to evict

Annotate DNS pods to enable the cluster autoscaler to evict them when scaling down a node.

Before this change, node scale-in could cause DNS disruption for tainted nodes.  If a node is tainted such that it has no DNS pod, then DNS queries originating on that node are forwarded to DNS pods on other nodes.  If one of these nodes was removed by scale-in or otherwise, the DNS pod on that node would be abruptly removed when the node shut down, and it would take some time for the node lifecycle controller to mark the pod as not ready, then for the endpoints controller and endpointslice controller to remove the pod's endpoint, and then for the service proxy to stop forwarding queries to the pod.  This delay could cause DNS lookup failures when queries were sent to a pod that had been on a removed node.  After this change, the cluster autoscaler should evict the DNS pod before removing the node, which should prevent disruption to the DNS service.

* `pkg/operator/controller/controller_dns_daemonset.go` (`enableDaemonSetEvictionAnnotationKey`): New const for the `cluster-autoscaler.kubernetes.io/enable-ds-eviction` pod annotation key.
(`managedDNSDaemonSetAnnotations`): New variable for annotation keys of annotations that the operator manages on DNS daemonsets.  For now, this only includes `enableDaemonSetEvictionAnnotationKey`.
(`desiredDNSDaemonSet`): Specify the `cluster-autoscaler.kubernetes.io/enable-ds-eviction` pod annotation.
(`daemonsetConfigChanged`): Check whether any managed annotations changed, and update annotations as appropriate.
* `pkg/operator/controller/controller_dns_daemonset_test.go` (`TestDesiredDNSDaemonset`): Verify that `desiredDNSDaemonSet` sets the expected pod annotations and labels.
(`TestDaemonsetConfigChanged`): Verify that `daemonsetConfigChanged` returns true if the `cluster-autoscaler.kubernetes.io/enable-ds-eviction` pod annotation is changed and false if only some other annotation changed.

#### Keep dns-default annotations intact

When adding the `cluster-autoscaler.kubernetes.io/enable-ds-eviction` annotation to DNS pods, do not overwrite other annotations.  In particular, preserve the `target.workload.openshift.io/management` annotation.

* `pkg/operator/controller/controller_dns_daemonset.go` (`targetWorkloadManagementAnnotationKey`): New const.
(`managedDNSDaemonSetAnnotations`): Add `targetWorkloadManagementAnnotationKey`.
(`desiredDNSDaemonSet`): Preserve annotations that are specified in the manifest.  
* `pkg/operator/controller/controller_dns_daemonset_test.go` (`TestDesiredDNSDaemonset`): Expect the `target.workload.openshift.io/management` annotation to be set.
(`TestDaemonsetConfigChanged`): Verify that the `cluster-autoscaler.kubernetes.io/enable-ds-eviction` and `target.workload.openshift.io/management` annotations are managed.  
* `test/e2e/operator_test.go` (`TestOperatorRecreatesItsManagedAnnotations`): New test.  Verify that the operator sets the `cluster-autoscaler.kubernetes.io/enable-ds-eviction` and `target.workload.openshift.io/management` annotations and restores them if they are removed.

--

This is a manual cherry-pick of #320 and #340.  