### PR TITLE
OCPBUGS-14395: Set controller-runtime logger to a null logger

### DIFF
--- a/cmd/dns-operator/main.go
+++ b/cmd/dns-operator/main.go
@@ -7,9 +7,11 @@ import (
 	operatorconfig "github.com/openshift/cluster-dns-operator/pkg/operator/config"
 	statuscontroller "github.com/openshift/cluster-dns-operator/pkg/operator/controller/status"
 
+	"github.com/go-logr/logr"
 	"github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
@@ -18,6 +20,12 @@ const operatorNamespace = "openshift-dns-operator"
 
 func main() {
 	metrics.DefaultBindAddress = "127.0.0.1:60000"
+
+	// This is required because controller-runtime expects its consumers to
+	// set a logger through log.SetLogger within 30 seconds of the program's
+	// initalization. We have our own logger and can configure controller-runtime's
+	// logger to do nothing.
+	ctrlruntimelog.SetLogger(logr.New(ctrlruntimelog.NullLogSink{}))
 
 	// Collect operator configuration.
 	releaseVersion := os.Getenv("RELEASE_VERSION")

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/apparentlymart/go-cidr v1.0.0
+	github.com/go-logr/logr v1.2.4
 	github.com/google/go-cmp v0.5.9
 	github.com/kevinburke/go-bindata v3.11.0+incompatible
 	github.com/openshift/api v0.0.0-20230503133300-8bbcb7ca7183
@@ -26,7 +27,6 @@ require (
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
-	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.1 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect


### PR DESCRIPTION
Due to controller-runtime v0.15.0 bump and changes made in https://github.com/kubernetes-sigs/controller-runtime/pull/2317, you must set a logger for controller-runtime. We have our own, so we will set controller-runtime's logger to Null.
    
`cmd/dns-operator/main.go`: Set a null logger for controller runtime on startup.
`go.mod`: `go mod tidy` update. Move logr from indirect to direct
dependency.
