### PR TITLE
OCPBUGS-15605: Update bufsize to 1232 bytes

### DIFF
--- a/pkg/operator/controller/controller_dns_configmap.go
+++ b/pkg/operator/controller/controller_dns_configmap.go
@@ -64,14 +64,14 @@ var corefileTemplate = template.Must(template.New("Corefile").Funcs(template.Fun
     log . {
         {{$.LogLevel}}
     }
-    bufsize 512
+    bufsize 1232
     cache {{ $.PositiveTTL }} {
         denial 9984 {{ $.NegativeTTL }}
     }
 }
 {{end -}}
 .:5353 {
-    bufsize 512
+    bufsize 1232
     errors
     log . {
         {{.LogLevel}}

--- a/pkg/operator/controller/testdata/1ipv6_and_policy
+++ b/pkg/operator/controller/testdata/1ipv6_and_policy
@@ -8,13 +8,13 @@ foo.com:5353 {
     log . {
         class error
     }
-    bufsize 512
+    bufsize 1232
     cache 900 {
         denial 9984 30
     }
 }
 .:5353 {
-    bufsize 512
+    bufsize 1232
     errors
     log . {
         class error

--- a/pkg/operator/controller/testdata/1ns_and_policy
+++ b/pkg/operator/controller/testdata/1ns_and_policy
@@ -8,13 +8,13 @@ foo.com:5353 {
     log . {
         class error
     }
-    bufsize 512
+    bufsize 1232
     cache 900 {
         denial 9984 30
     }
 }
 .:5353 {
-    bufsize 512
+    bufsize 1232
     errors
     log . {
         class error

--- a/pkg/operator/controller/testdata/1ns_no_policy
+++ b/pkg/operator/controller/testdata/1ns_no_policy
@@ -8,13 +8,13 @@ foo.com:5353 {
     log . {
         class error
     }
-    bufsize 512
+    bufsize 1232
     cache 900 {
         denial 9984 30
     }
 }
 .:5353 {
-    bufsize 512
+    bufsize 1232
     errors
     log . {
         class error

--- a/pkg/operator/controller/testdata/1sysresconf
+++ b/pkg/operator/controller/testdata/1sysresconf
@@ -8,13 +8,13 @@ foo.com:5353 {
     log . {
         class error
     }
-    bufsize 512
+    bufsize 1232
     cache 900 {
         denial 9984 30
     }
 }
 .:5353 {
-    bufsize 512
+    bufsize 1232
     errors
     log . {
         class error

--- a/pkg/operator/controller/testdata/5upstreams
+++ b/pkg/operator/controller/testdata/5upstreams
@@ -8,13 +8,13 @@ foo.com:5353 {
     log . {
         class error
     }
-    bufsize 512
+    bufsize 1232
     cache 900 {
         denial 9984 30
     }
 }
 .:5353 {
-    bufsize 512
+    bufsize 1232
     errors
     log . {
         class error

--- a/pkg/operator/controller/testdata/debug_loglevel
+++ b/pkg/operator/controller/testdata/debug_loglevel
@@ -8,13 +8,13 @@ foo.com:5353 {
     log . {
         class denial error
     }
-    bufsize 512
+    bufsize 1232
     cache 900 {
         denial 9984 30
     }
 }
 .:5353 {
-    bufsize 512
+    bufsize 1232
     errors
     log . {
         class denial error

--- a/pkg/operator/controller/testdata/default_corefile
+++ b/pkg/operator/controller/testdata/default_corefile
@@ -8,7 +8,7 @@ foo.com:5353 {
     log . {
         class error
     }
-    bufsize 512
+    bufsize 1232
     cache 900 {
         denial 9984 30
     }
@@ -23,7 +23,7 @@ bar.com:5353 example.com:5353 {
     log . {
         class error
     }
-    bufsize 512
+    bufsize 1232
     cache 900 {
         denial 9984 30
     }
@@ -38,7 +38,7 @@ fizz.com:5353 {
     log . {
         class error
     }
-    bufsize 512
+    bufsize 1232
     cache 900 {
         denial 9984 30
     }
@@ -53,13 +53,13 @@ buzz.com:5353 example.buzz.com:5353 {
     log . {
         class error
     }
-    bufsize 512
+    bufsize 1232
     cache 900 {
         denial 9984 30
     }
 }
 .:5353 {
-    bufsize 512
+    bufsize 1232
     errors
     log . {
         class error

--- a/pkg/operator/controller/testdata/default_corefile_cache_configured
+++ b/pkg/operator/controller/testdata/default_corefile_cache_configured
@@ -1,5 +1,5 @@
 .:5353 {
-    bufsize 512
+    bufsize 1232
     errors
     log . {
         class error

--- a/pkg/operator/controller/testdata/default_corefile_cache_with_fractional_values_configured
+++ b/pkg/operator/controller/testdata/default_corefile_cache_with_fractional_values_configured
@@ -1,5 +1,5 @@
 .:5353 {
-    bufsize 512
+    bufsize 1232
     errors
     log . {
         class error

--- a/pkg/operator/controller/testdata/default_corefile_no_cache_configured
+++ b/pkg/operator/controller/testdata/default_corefile_no_cache_configured
@@ -1,5 +1,5 @@
 .:5353 {
-    bufsize 512
+    bufsize 1232
     errors
     log . {
         class error

--- a/pkg/operator/controller/testdata/duplicate_upstreams
+++ b/pkg/operator/controller/testdata/duplicate_upstreams
@@ -8,13 +8,13 @@ foo.com:5353 {
     log . {
         class error
     }
-    bufsize 512
+    bufsize 1232
     cache 900 {
         denial 9984 30
     }
 }
 .:5353 {
-    bufsize 512
+    bufsize 1232
     errors
     log . {
         class error

--- a/pkg/operator/controller/testdata/empty_upstreams_array
+++ b/pkg/operator/controller/testdata/empty_upstreams_array
@@ -8,13 +8,13 @@ foo.com:5353 {
     log . {
         class error
     }
-    bufsize 512
+    bufsize 1232
     cache 900 {
         denial 9984 30
     }
 }
 .:5353 {
-    bufsize 512
+    bufsize 1232
     errors
     log . {
         class error

--- a/pkg/operator/controller/testdata/forwardplugin_protocolstrategy_none
+++ b/pkg/operator/controller/testdata/forwardplugin_protocolstrategy_none
@@ -8,13 +8,13 @@ foo.com:5353 {
     log . {
         class error
     }
-    bufsize 512
+    bufsize 1232
     cache 900 {
         denial 9984 30
     }
 }
 .:5353 {
-    bufsize 512
+    bufsize 1232
     errors
     log . {
         class error

--- a/pkg/operator/controller/testdata/forwardplugin_protocolstrategy_tcp
+++ b/pkg/operator/controller/testdata/forwardplugin_protocolstrategy_tcp
@@ -9,13 +9,13 @@ foo.com:5353 {
     log . {
         class error
     }
-    bufsize 512
+    bufsize 1232
     cache 900 {
         denial 9984 30
     }
 }
 .:5353 {
-    bufsize 512
+    bufsize 1232
     errors
     log . {
         class error

--- a/pkg/operator/controller/testdata/forwardplugin_tls
+++ b/pkg/operator/controller/testdata/forwardplugin_tls
@@ -10,7 +10,7 @@ foo.com:5353 {
     log . {
         class error
     }
-    bufsize 512
+    bufsize 1232
     cache 900 {
         denial 9984 30
     }
@@ -27,13 +27,13 @@ bar.com:5353 {
     log . {
         class error
     }
-    bufsize 512
+    bufsize 1232
     cache 900 {
         denial 9984 30
     }
 }
 .:5353 {
-    bufsize 512
+    bufsize 1232
     errors
     log . {
         class error

--- a/pkg/operator/controller/testdata/just_policy
+++ b/pkg/operator/controller/testdata/just_policy
@@ -8,13 +8,13 @@ foo.com:5353 {
     log . {
         class error
     }
-    bufsize 512
+    bufsize 1232
     cache 900 {
         denial 9984 30
     }
 }
 .:5353 {
-    bufsize 512
+    bufsize 1232
     errors
     log . {
         class error

--- a/pkg/operator/controller/testdata/mult_upstreamresolvers
+++ b/pkg/operator/controller/testdata/mult_upstreamresolvers
@@ -8,13 +8,13 @@ foo.com:5353 {
     log . {
         class error
     }
-    bufsize 512
+    bufsize 1232
     cache 900 {
         denial 9984 30
     }
 }
 .:5353 {
-    bufsize 512
+    bufsize 1232
     errors
     log . {
         class error

--- a/pkg/operator/controller/testdata/normal_loglevel
+++ b/pkg/operator/controller/testdata/normal_loglevel
@@ -8,13 +8,13 @@ foo.com:5353 {
     log . {
         class error
     }
-    bufsize 512
+    bufsize 1232
     cache 900 {
         denial 9984 30
     }
 }
 .:5353 {
-    bufsize 512
+    bufsize 1232
     errors
     log . {
         class error

--- a/pkg/operator/controller/testdata/tls_with_non_existing_cabundle
+++ b/pkg/operator/controller/testdata/tls_with_non_existing_cabundle
@@ -1,5 +1,5 @@
 .:5353 {
-    bufsize 512
+    bufsize 1232
     errors
     log . {
         class error

--- a/pkg/operator/controller/testdata/trace_loglevel
+++ b/pkg/operator/controller/testdata/trace_loglevel
@@ -8,13 +8,13 @@ foo.com:5353 {
     log . {
         class all
     }
-    bufsize 512
+    bufsize 1232
     cache 900 {
         denial 9984 30
     }
 }
 .:5353 {
-    bufsize 512
+    bufsize 1232
     errors
     log . {
         class all

--- a/pkg/operator/controller/testdata/upstreamresolver_protocolstrategy_none
+++ b/pkg/operator/controller/testdata/upstreamresolver_protocolstrategy_none
@@ -1,5 +1,5 @@
 .:5353 {
-    bufsize 512
+    bufsize 1232
     errors
     log . {
         class error

--- a/pkg/operator/controller/testdata/upstreamresolver_protocolstrategy_tcp
+++ b/pkg/operator/controller/testdata/upstreamresolver_protocolstrategy_tcp
@@ -1,5 +1,5 @@
 .:5353 {
-    bufsize 512
+    bufsize 1232
     errors
     log . {
         class error

--- a/pkg/operator/controller/testdata/upstreamresolvers_with_cabundle
+++ b/pkg/operator/controller/testdata/upstreamresolvers_with_cabundle
@@ -1,5 +1,5 @@
 .:5353 {
-    bufsize 512
+    bufsize 1232
     errors
     log . {
         class error

--- a/pkg/operator/controller/testdata/upstreams_type_empty
+++ b/pkg/operator/controller/testdata/upstreams_type_empty
@@ -8,13 +8,13 @@ foo.com:5353 {
     log . {
         class error
     }
-    bufsize 512
+    bufsize 1232
     cache 900 {
         denial 9984 30
     }
 }
 .:5353 {
-    bufsize 512
+    bufsize 1232
     errors
     log . {
         class error

--- a/pkg/operator/controller/testdata/without_upstreamresolvers
+++ b/pkg/operator/controller/testdata/without_upstreamresolvers
@@ -8,13 +8,13 @@ foo.com:5353 {
     log . {
         class error
     }
-    bufsize 512
+    bufsize 1232
     cache 900 {
         denial 9984 30
     }
 }
 .:5353 {
-    bufsize 512
+    bufsize 1232
     errors
     log . {
         class error


### PR DESCRIPTION
As endorsed at [DNS Flag Day](http://www.dnsflagday.net/2020/), the DNS Community recommends a bufsize setting of 1232 as a safe default that supports larger payloads, while generally avoiding IP fragmentation on most networks. This is particularly relevant for payloads like those generated by DNSSEC, which tend to be larger.

Previously, CoreDNS always used the EDNS0 extension, which enables UDP-based DNS queries to exceed 512 bytes, when CoreDNS forwarded DNS queries to an upstream name server, and so OpenShift specified a bufsize setting of 512 to maintain compatibility with applications and name servers that did not support the EDNS0 extension.

For clients and name servers that do support EDNS0, a bufsize setting of 512 can result in more DNS truncation and unnecessary TCP retransmissions, resulting in worse DNS performance for most users. This is due to the fact that if a response is larger than the bufsize setting, it gets truncated, prompting clients to initiate a TCP retry. In this situation, two DNS requests are made for a single DNS answer, leading to higher bandwidth usage and longer response times.

Currently, CoreDNS no longer uses EDNS0 when forwarding requests if the original client request did not use EDNS0 (ref: https://github.com/coredns/coredns/commit/a5b9749462a9717c8920dba095f242611c61a989), and so the reasoning for using a bufsize setting of 512 no longer applies. By increasing the bufsize setting to the recommended value of 1232 bytes, we can enhance DNS performance by decreasing the probability of DNS truncations.

Using a larger bufsize setting of 1232 bytes also would potentially help alleviate bugs like https://issues.redhat.com/browse/OCPBUGS-6829 in which a non-compliant upstream DNS is not respecting a bufsize of 512 bytes and sending larger-than-512-bytes responses. A bufsize setting of 1232 bytes doesn't fix the root cause of this issue; rather, it decreases the likelihood of its occurrence by increasing the acceptable size range for UDP responses. 

Note that clients that don’t support EDNS0 or TCP, such as applications built using older versions of Alpine Linux, are still subject to the aforementioned truncation issue. To avoid these issues, ensure that your application is built using a DNS resolver library that supports EDNS0 or TCP-based DNS queries.

**Brief history of OpenShift's Bufsize changes:**

1. During the development of OpenShift 4.8.0, we updated to 1232 bytes due to [Bug - 1949361](https://bugzilla.redhat.com/show_bug.cgi?id=1949361) and backported to 4.7 and 4.6. However, later on, 4.8.0 (in development), 4.7, and 4.6 were reverted back to 512 bytes due to [Bug - 1966116](https://bugzilla.redhat.com/show_bug.cgi?id=1966116).
2. Also in OpenShift 4.8.0, we bumped CoreDNS to v1.8.1, and picked up a [commit](https://github.com/coredns/coredns/commit/acf9a0fa19928e605ac8ac3314890c9fef73e16b) that forced DNS queries that did not have the DO Bit (DNSSEC) set to set bufsize as 2048 bytes despite 512 bytes being set in the configuration.
3. In OpenShift 4.12.0, we fixed [OCPBUGS-240](https://issues.redhat.com/browse/OCPBUGS-240) to limit all DNS queries, specifically queries that had DO Bit off, to what is configured in the configuration file (512 bytes) and we backported the fix to 4.11, 4.10, and 4.9.
4. Now, this PR is changing bufsize to 1232 bytes.

[Slack Thread](https://redhat-internal.slack.com/archives/CCH60A77E/p1688045451445629)