### PR TITLE
OCPBUGS-12863: Replace Bugzilla link with Red Hat Issue Tracker

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 contact_links:
-- name: File a Bugzilla report
-  url: https://bugzilla.redhat.com/enter_bug.cgi?product=OpenShift%20Container%20Platform&component=Networking&sub_component=DNS
-  about: Please use Bugzilla to report issues.
+- name: File a bug report
+  url: https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12332330&issuetype=1&components=12367613&priority=10300&customfield_12316142=26752
+  about: Please use the Red Hat Issue Tracker to report bugs.
 - name: DNS Operator in OpenShift Container Platform
   url: https://docs.openshift.com/container-platform/latest/networking/dns-operator.html
   about: Refer to the OpenShift Container Platform documentation for information about the DNS Operator in OpenShift Container Platform.

--- a/OWNERS
+++ b/OWNERS
@@ -1,27 +1,22 @@
 approvers:
-  - ironcladlou
   - knobunc
-  - pravisankar
-  - ramr
   - Miciah
   - frobware
-  - danehans
-  - sgreene570
   - candita
   - rfredette
   - alebedev87
   - gcs278
 reviewers:
-  - ironcladlou
   - knobunc
-  - pravisankar
-  - ramr
   - Miciah
   - frobware
-  - danehans
-  - sgreene570
   - candita
   - rfredette
   - alebedev87
   - gcs278
-component: DNS
+emeritus_approvers:
+  - ironcladlou
+  - pravisankar
+  - ramr
+  - danehans
+  - sgreene570

--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ See [HACKING.md](HACKING.md) for development topics.
 
 ## Reporting issues
 
-Bugs are tracked in [Bugzilla](https://bugzilla.redhat.com/enter_bug.cgi?product=OpenShift%20Container%20Platform&component=Networking&sub_component=DNS).
+Bugs are tracked in [the Red Hat Issue Tracker](https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12332330&issuetype=1&components=12367613&priority=10300&customfield_12316142=26752).


### PR DESCRIPTION
* `.github/ISSUE_TEMPLATE/config.yml`: Update the Bugzilla link to point instead to the Red Hat Issue Tracker.
* `Owners`: Remove the component field.  Add past approvers to `emeritus_approvers` and remove them from the `approvers` and `reviewers` lists.
* `README.md`: Update the Bugzilla link.

---

This PR is similar to https://github.com/openshift/cluster-ingress-operator/pull/916 and https://github.com/openshift/cluster-ingress-operator/pull/968.