### PR TITLE
OCPBUGS-18034: Only bump lastTransitionTime on 'status' changes

### DIFF
--- a/pkg/operator/controller/dns_status.go
+++ b/pkg/operator/controller/dns_status.go
@@ -265,8 +265,7 @@ func computeDNSUpgradeableCondition(oldCondition *operatorv1.OperatorCondition, 
 // setDNSLastTransitionTime sets LastTransitionTime for the given condition.
 // If the condition has changed, it will assign a new timestamp otherwise keeps the old timestamp.
 func setDNSLastTransitionTime(condition, oldCondition *operatorv1.OperatorCondition) operatorv1.OperatorCondition {
-	if oldCondition != nil && condition.Status == oldCondition.Status &&
-		condition.Reason == oldCondition.Reason && condition.Message == oldCondition.Message {
+	if oldCondition != nil && condition.Status == oldCondition.Status {
 		condition.LastTransitionTime = oldCondition.LastTransitionTime
 	} else {
 		condition.LastTransitionTime = metav1.Now()

--- a/pkg/operator/controller/status/controller.go
+++ b/pkg/operator/controller/status/controller.go
@@ -625,13 +625,13 @@ func mergeConditions(conditions []configv1.ClusterOperatorStatusCondition, updat
 		for j, cond := range conditions {
 			if cond.Type == update.Type {
 				add = false
-				if conditionChanged(cond, update) {
-					conditions[j].Status = update.Status
-					conditions[j].Reason = update.Reason
-					conditions[j].Message = update.Message
+				if conditions[j].Status != update.Status {
 					conditions[j].LastTransitionTime = now
-					break
 				}
+				conditions[j].Status = update.Status
+				conditions[j].Reason = update.Reason
+				conditions[j].Message = update.Message
+				break
 			}
 		}
 		if add {
@@ -641,10 +641,6 @@ func mergeConditions(conditions []configv1.ClusterOperatorStatusCondition, updat
 	}
 	conditions = append(conditions, additions...)
 	return conditions
-}
-
-func conditionChanged(a, b configv1.ClusterOperatorStatusCondition) bool {
-	return a.Status != b.Status || a.Reason != b.Reason || a.Message != b.Message
 }
 
 // operatorStatusesEqual compares two ClusterOperatorStatus values.  Returns true


### PR DESCRIPTION
From [the API docs][1]:

    lastTransitionTime is the time of the last update to the current status property.

And [the library-go `SetStatusCondition` implementation][2] includes:

```go
  if existingCondition.Status != newCondition.Status {
    existingCondition.Status = newCondition.Status
    existingCondition.LastTransitionTime = metav1.NewTime(time.Now())
  }

  existingCondition.Reason = newCondition.Reason
  existingCondition.Message = newCondition.Message
```

The motivation for that behavior is that it's often more useful to know "how long has this resource been `Degraded=True`?" and similar than it is to know how long it has had exactly the same `status`/`reason`/`message`. Messages in particular can be fairly mutable (`# of # pods available`, etc.), and changes there do not necessarily represent fundamental shifts in the underlying issue.

[1]: https://github.com/openshift/api/blob/81f778f3b3ec31c1dd344e795620a8fbaf2d9a51/config/v1/types_cluster_operator.go#L129
[2]: https://github.com/openshift/library-go/blob/c515269de16e5e239bd6e93e1f9821a976bb460b/pkg/config/clusteroperator/v1helpers/status.go#L29C1-L35C50