### PR TITLE
pkg/operator/controller/dns_status: Allow 10% unavailable before going Degraded=True

### DIFF
--- a/pkg/operator/controller/dns_status.go
+++ b/pkg/operator/controller/dns_status.go
@@ -265,8 +265,7 @@ func computeDNSUpgradeableCondition(oldCondition *operatorv1.OperatorCondition, 
 // setDNSLastTransitionTime sets LastTransitionTime for the given condition.
 // If the condition has changed, it will assign a new timestamp otherwise keeps the old timestamp.
 func setDNSLastTransitionTime(condition, oldCondition *operatorv1.OperatorCondition) operatorv1.OperatorCondition {
-	if oldCondition != nil && condition.Status == oldCondition.Status &&
-		condition.Reason == oldCondition.Reason && condition.Message == oldCondition.Message {
+	if oldCondition != nil && condition.Status == oldCondition.Status {
 		condition.LastTransitionTime = oldCondition.LastTransitionTime
 	} else {
 		condition.LastTransitionTime = metav1.Now()

--- a/pkg/operator/controller/dns_status.go
+++ b/pkg/operator/controller/dns_status.go
@@ -100,8 +100,8 @@ func computeDNSDegradedCondition(oldCondition *operatorv1.OperatorCondition, clu
 		want := dnsDaemonset.Status.DesiredNumberScheduled
 		have := dnsDaemonset.Status.NumberAvailable
 		numberUnavailable := want - have
-		maxUnavailableIntStr := intstr.FromInt(1)
-		if dnsDaemonset.Spec.UpdateStrategy.RollingUpdate != nil && dnsDaemonset.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable != nil {
+		maxUnavailableIntStr := intstr.FromString("10%")
+		if dnsDaemonset.Spec.UpdateStrategy.RollingUpdate != nil && dnsDaemonset.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable != nil && dnsDaemonset.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable.String() != "0" {
 			maxUnavailableIntStr = *dnsDaemonset.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable
 		}
 		maxUnavailable, intstrErr := intstr.GetScaledValueFromIntOrPercent(&maxUnavailableIntStr, int(want), true)
@@ -120,7 +120,7 @@ func computeDNSDegradedCondition(oldCondition *operatorv1.OperatorCondition, clu
 		case int(numberUnavailable) > maxUnavailable:
 			status = operatorv1.ConditionTrue
 			degradedReasons = append(degradedReasons, "MaxUnavailableDNSPodsExceeded")
-			messages = append(messages, fmt.Sprintf("Too many DNS pods are unavailable (%d > %d max unavailable).", numberUnavailable, maxUnavailable))
+			messages = append(messages, fmt.Sprintf("Too many DNS pods are unavailable (%d > %d max unavailable %q).", numberUnavailable, maxUnavailable, maxUnavailableIntStr.String()))
 		}
 	}
 

--- a/pkg/operator/controller/status/controller.go
+++ b/pkg/operator/controller/status/controller.go
@@ -625,13 +625,13 @@ func mergeConditions(conditions []configv1.ClusterOperatorStatusCondition, updat
 		for j, cond := range conditions {
 			if cond.Type == update.Type {
 				add = false
-				if conditionChanged(cond, update) {
-					conditions[j].Status = update.Status
-					conditions[j].Reason = update.Reason
-					conditions[j].Message = update.Message
+				if conditions[j].Status != update.Status {
 					conditions[j].LastTransitionTime = now
-					break
 				}
+				conditions[j].Status = update.Status
+				conditions[j].Reason = update.Reason
+				conditions[j].Message = update.Message
+				break
 			}
 		}
 		if add {
@@ -641,10 +641,6 @@ func mergeConditions(conditions []configv1.ClusterOperatorStatusCondition, updat
 	}
 	conditions = append(conditions, additions...)
 	return conditions
-}
-
-func conditionChanged(a, b configv1.ClusterOperatorStatusCondition) bool {
-	return a.Status != b.Status || a.Reason != b.Reason || a.Message != b.Message
 }
 
 // operatorStatusesEqual compares two ClusterOperatorStatus values.  Returns true


### PR DESCRIPTION
Layering a new one-line pivot on top of #375, to see how they play together.

5c4f0ad3430a (#358) pivoted the dns-default DaemonSet from 10% `maxUnavailable` to 10% `maxSurge`.  That left this "is this DaemonSet sad?" checker defaulting to "if there are any more than one unready DNS pods, we're sad".  But in many clusters, especially large ones with the DaemonSet trying to schedule pods on many compute nodes, there are often more than 1 unready pod, and going `Degraded=True` is distracting noise, and not something that has a quality-of-service impact.  This commit adjusts the default to the old 10% `maxUnavailable`, so we have a less twitchy value we can use for surging DaemonSets.  We can't set that on the DaemonSet itself, because as described in 5c4f0ad3430a, API validation prevents us from setting `maxSurge` and `maxUnavailable` simultaneously.