### PR TITLE
pkg/operator/controller/status: 5 minutes of inertia before propagating Degraded=True

### DIFF
--- a/pkg/operator/controller/dns_status.go
+++ b/pkg/operator/controller/dns_status.go
@@ -265,8 +265,7 @@ func computeDNSUpgradeableCondition(oldCondition *operatorv1.OperatorCondition, 
 // setDNSLastTransitionTime sets LastTransitionTime for the given condition.
 // If the condition has changed, it will assign a new timestamp otherwise keeps the old timestamp.
 func setDNSLastTransitionTime(condition, oldCondition *operatorv1.OperatorCondition) operatorv1.OperatorCondition {
-	if oldCondition != nil && condition.Status == oldCondition.Status &&
-		condition.Reason == oldCondition.Reason && condition.Message == oldCondition.Message {
+	if oldCondition != nil && condition.Status == oldCondition.Status {
 		condition.LastTransitionTime = oldCondition.LastTransitionTime
 	} else {
 		condition.LastTransitionTime = metav1.Now()

--- a/pkg/operator/controller/status/controller.go
+++ b/pkg/operator/controller/status/controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -417,7 +418,7 @@ func computeOperatorDegradedCondition(haveDNS bool, dns *operatorv1.DNS) configv
 
 	var degraded bool
 	for _, cond := range dns.Status.Conditions {
-		if cond.Type == operatorv1.OperatorStatusTypeDegraded && cond.Status == operatorv1.ConditionTrue {
+		if cond.Type == operatorv1.OperatorStatusTypeDegraded && cond.Status == operatorv1.ConditionTrue && time.Now().Sub(cond.LastTransitionTime.Time) > 5*time.Minute {
 			degraded = true
 		}
 	}

--- a/pkg/operator/controller/status/controller.go
+++ b/pkg/operator/controller/status/controller.go
@@ -625,13 +625,13 @@ func mergeConditions(conditions []configv1.ClusterOperatorStatusCondition, updat
 		for j, cond := range conditions {
 			if cond.Type == update.Type {
 				add = false
-				if conditionChanged(cond, update) {
-					conditions[j].Status = update.Status
-					conditions[j].Reason = update.Reason
-					conditions[j].Message = update.Message
+				if conditions[j].Status != update.Status {
 					conditions[j].LastTransitionTime = now
-					break
 				}
+				conditions[j].Status = update.Status
+				conditions[j].Reason = update.Reason
+				conditions[j].Message = update.Message
+				break
 			}
 		}
 		if add {
@@ -641,10 +641,6 @@ func mergeConditions(conditions []configv1.ClusterOperatorStatusCondition, updat
 	}
 	conditions = append(conditions, additions...)
 	return conditions
-}
-
-func conditionChanged(a, b configv1.ClusterOperatorStatusCondition) bool {
-	return a.Status != b.Status || a.Reason != b.Reason || a.Message != b.Message
 }
 
 // operatorStatusesEqual compares two ClusterOperatorStatus values.  Returns true


### PR DESCRIPTION
Layering on top of both #375 ~and #376~.

The default DNS resource can go `Degraded=True` when it has insufficient available pods.  But it's possible to have insufficient available pods momentarily and subsequently recover.  For example, while the DaemonSet is rolling out an update, we expect `maxSurge` unavailable pods for the duration of the rollout, which could involve up to 10 (for 10% `maxSurge`) rounds of pods being spun up on the cluster's nodes:

1. DaemonSet bumped.
2. Pod a2 launched on node a, pod b2 launched on node b, etc.
3. Pod a2 goes ready, and the old pod a1 is deleted.
4. Pod c2 launched on node c.
5. Pod b2 goes ready, and the  old pod b1 is deleted.
...
n. Eventually all the new pods are ready.

During that rollout, there are always some unready pods.  But we're still making quick progress and things are happy. 
  However, we could also have:

1. DaemonSet bumped.
2. Pod a2 launched on node a, pod b2 launched on node b, etc.
3. Pod b2 goes ready, and the  old pod b1 is deleted.
4. Pod c2 launched on node c.
...
n. Pod a2 still stuck.

That will have a similar number of unready pods as the happy case, but a2 being stuck for so long is a bad sign, and might deserve admin intervention.  Ideally the DaemonSet controller would be watching individual pods and reporting conditions to let us know if it was concerned about progress or recovery from external disruption.  But [DaemonSet `status` has no conditions today][1].  We could look over the DaemonSet controller's shoulder and watch the pods directly, but that would be a lot of work.  So instead I'm adding a few minutes of inertia here, assuming that if the unready pods quickly resolve, it's unlikely to impact quality-of-service or require admin intervention.  And if the unready pods (or other issue) does not quickly resolve, it is likely to deserve admin intervention (now with some hopefully acceptable additional latency before summoning the admin).

[1]: https://github.com/kubernetes/kubernetes/blob/98358b8ce11b0c1878ae7aa1482668cb7a0b0e23/staging/src/k8s.io/api/apps/v1/types.go#L722