### PR TITLE
OCPBUGS-13209: Revert "Set DNS DaemonSet's maxSurge value to 10%"

### DIFF
--- a/pkg/manifests/assets/dns/daemonset.yaml
+++ b/pkg/manifests/assets/dns/daemonset.yaml
@@ -2,8 +2,6 @@ kind: DaemonSet
 apiVersion: apps/v1
 # name, namespace and labels are set at runtime
 spec:
-  # minReadySeconds should be 3x the readiness probe's polling interval (i.e. periodSeconds).
-  minReadySeconds: 9
   template:
     metadata:
       annotations:
@@ -35,7 +33,7 @@ spec:
             port: 8181
             scheme: HTTP
           initialDelaySeconds: 10
-          periodSeconds: 3 # Update the daemonset's spec.minReadySeconds above if you change this value!
+          periodSeconds: 3
           successThreshold: 1
           failureThreshold: 3
           timeoutSeconds: 3
@@ -87,11 +85,8 @@ spec:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      # Set maxSurge to a positive value so that each node that has a pod
-      # continues to have a local ready pod during a rolling update.  This is
-      # important for topology-aware hints as well as for similar logic in
-      # openshift-sdn and ovn-kubernetes that prefers to use a local ready DNS
-      # pod whenever one exists.
-      maxSurge: 10%
-      # maxUnavailable must be zero when maxSurge is nonzero.
-      maxUnavailable: 0
+      # TODO: Consider setting maxSurge to a positive value.
+      maxSurge: 0
+      # Note: The daemon controller rounds the percentage up
+      # (unlike the deployment controller, which rounds down).
+      maxUnavailable: 10%

--- a/pkg/operator/controller/controller_dns_daemonset.go
+++ b/pkg/operator/controller/controller_dns_daemonset.go
@@ -337,11 +337,6 @@ func daemonsetConfigChanged(current, expected *appsv1.DaemonSet) (bool, *appsv1.
 	changed := false
 	updated := current.DeepCopy()
 
-	if current.Spec.MinReadySeconds != expected.Spec.MinReadySeconds {
-		updated.Spec.MinReadySeconds = expected.Spec.MinReadySeconds
-		changed = true
-	}
-
 	if !cmp.Equal(current.Spec.UpdateStrategy, expected.Spec.UpdateStrategy, cmpopts.EquateEmpty()) {
 		updated.Spec.UpdateStrategy = expected.Spec.UpdateStrategy
 		changed = true

--- a/pkg/operator/controller/controller_dns_daemonset_test.go
+++ b/pkg/operator/controller/controller_dns_daemonset_test.go
@@ -27,18 +27,6 @@ func TestDesiredDNSDaemonset(t *testing.T) {
 		t.Errorf("invalid dns daemonset: %v", err)
 	} else {
 		// Validate the daemonset
-		pointerTo := func(ios intstr.IntOrString) *intstr.IntOrString { return &ios }
-		expectedUpdateStrategy := appsv1.DaemonSetUpdateStrategy{
-			Type: appsv1.RollingUpdateDaemonSetStrategyType,
-			RollingUpdate: &appsv1.RollingUpdateDaemonSet{
-				MaxSurge:       pointerTo(intstr.FromString("10%")),
-				MaxUnavailable: pointerTo(intstr.FromInt(0)),
-			},
-		}
-		actualUpdateStrategy := ds.Spec.UpdateStrategy
-		if !reflect.DeepEqual(actualUpdateStrategy, expectedUpdateStrategy) {
-			t.Errorf("unexpected update strategy: expected %#v, got %#v", expectedUpdateStrategy, actualUpdateStrategy)
-		}
 		expectedPodAnnotations := map[string]string{
 			"cluster-autoscaler.kubernetes.io/enable-ds-eviction": "true",
 			"target.workload.openshift.io/management":             "{\"effect\": \"PreferredDuringScheduling\"}",
@@ -481,23 +469,14 @@ func TestDaemonsetConfigChanged(t *testing.T) {
 			expect: true,
 		},
 		{
-			description: "if the update strategy's max unavailable parameter changes",
+			description: "if the update strategy changes",
 			mutate: func(daemonset *appsv1.DaemonSet) {
-				daemonset.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable = pointerTo(intstr.FromString("10%"))
-			},
-			expect: true,
-		},
-		{
-			description: "if the update strategy's max surge parameter changes",
-			mutate: func(daemonset *appsv1.DaemonSet) {
-				daemonset.Spec.UpdateStrategy.RollingUpdate.MaxSurge = pointerTo(intstr.FromString("10%"))
-			},
-			expect: true,
-		},
-		{
-			description: "if spec.minReadySeconds changes",
-			mutate: func(daemonset *appsv1.DaemonSet) {
-				daemonset.Spec.MinReadySeconds = 9
+				daemonset.Spec.UpdateStrategy = appsv1.DaemonSetUpdateStrategy{
+					Type: appsv1.RollingUpdateDaemonSetStrategyType,
+					RollingUpdate: &appsv1.RollingUpdateDaemonSet{
+						MaxUnavailable: pointerTo(intstr.FromString("10%")),
+					},
+				}
 			},
 			expect: true,
 		},


### PR DESCRIPTION
The daemon controller has a defect that prevents us from using maxSurge at this time; see <https://issues.redhat.com/browse/OCPBUGS-15531>.

This reverts #358.