### PR TITLE
OCPBUGS-20024: Ignore max unavailable for status

### DIFF
--- a/pkg/operator/controller/controller_dns_node_resolver_daemonset.go
+++ b/pkg/operator/controller/controller_dns_node_resolver_daemonset.go
@@ -77,7 +77,7 @@ func (r *reconciler) ensureNodeResolverDaemonSet(dns *operatorv1.DNS, clusterIP,
 // desiredNodeResolverDaemonSet returns the desired node resolver daemonset.
 func desiredNodeResolverDaemonSet(dns *operatorv1.DNS, clusterIP, clusterDomain, openshiftCLIImage string) (bool, *appsv1.DaemonSet, error) {
 	hostPathFile := corev1.HostPathFile
-	// TODO: Consider setting maxSurge to a positive value.
+	// maxSurge must be zero when maxUnavailable is nonzero.
 	maxSurge := intstr.FromInt(0)
 	maxUnavailable := intstr.FromString("33%")
 	envs := []corev1.EnvVar{{


### PR DESCRIPTION
Followup to PR #384.
- pkg/operator/controller/controller_dns_node_resolver_daemonset.go - small update to a comment
- pkg/operator/controller/dns_status.go - hardcode maxUnavailable to 10% of desiredNumberScheduled and remove condition "invalid maxUnavailable value"
- pkg/operator/controller/dns_status_test.go - remove maxUnavailable format testing