### PR TITLE
OCPBUGS-28230: add FallbackToLogsOnError for easier debugging

### DIFF
--- a/manifests/0000_70_dns-operator_02-deployment-ibm-cloud-managed.yaml
+++ b/manifests/0000_70_dns-operator_02-deployment-ibm-cloud-managed.yaml
@@ -63,6 +63,7 @@ spec:
           capabilities:
             drop:
             - ALL
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/tls/private
           name: metrics-tls

--- a/manifests/0000_70_dns-operator_02-deployment.yaml
+++ b/manifests/0000_70_dns-operator_02-deployment.yaml
@@ -75,6 +75,7 @@ spec:
           capabilities:
             drop:
             - ALL
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/tls/private
           name: metrics-tls

--- a/pkg/manifests/assets/dns/daemonset.yaml
+++ b/pkg/manifests/assets/dns/daemonset.yaml
@@ -68,6 +68,7 @@ spec:
           requests:
             cpu: 10m
             memory: 40Mi
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/tls/private
           name: metrics-tls


### PR DESCRIPTION
All openshift operators must include FallbackToLogsOnError to ease debugging.