### PR TITLE
OCPBUGS-32093: Add RBAC related to featuregates to fix hypershift upgrade

### DIFF
--- a/manifests/0000_70_dns-operator_00-cluster-role.yaml
+++ b/manifests/0000_70_dns-operator_00-cluster-role.yaml
@@ -111,3 +111,12 @@ rules:
   - clusteroperators/status
   verbs:
   - update
+
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - featuregates
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
#393 added RBAC for featuregates in the cluster role for dns operator as well as `configInformers.Config().V1().FeatureGates()` call in the dns operator in 4.16. This caused issues during upgrade of hypershift clusters from 4.15 to 4.16 as sometimes the deployment of the cluster dns operator may get upgraded before the cluster role which caused the dns operator to crashloop (by design) temporarily during the upgrade. This PR adds the required RBAC to the cluster role in 4.15 so that the dns operator doesn't crashloop (by design) during the upgrade of hypershift clusters from 4.15 to 4.16.