### PR TITLE
OCPBUGS-33750: Bump version of DNSNameResolver controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/openshift/api v0.0.0-20240510053056-88a8afea030c
 	github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d
 	github.com/openshift/client-go v0.0.0-20231024221206-506d798bc61c
-	github.com/openshift/coredns-ocp-dnsnameresolver/operator v0.0.0-20240514135022-c41cdd134379
+	github.com/openshift/coredns-ocp-dnsnameresolver/operator v0.0.0-20240712094134-af651cec05d1
 	github.com/openshift/library-go v0.0.0-20231102154438-cfcf2b4fbc87
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d h1:RR
 github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20231024221206-506d798bc61c h1:xfag+wccUqc9EdrWsnprD6x5KG2WE+iKGFfFELCwwRA=
 github.com/openshift/client-go v0.0.0-20231024221206-506d798bc61c/go.mod h1:3BkYp+FtKD2TypMD0nTPkVsxUaY4fJPLEMFMlOLtrJM=
-github.com/openshift/coredns-ocp-dnsnameresolver/operator v0.0.0-20240514135022-c41cdd134379 h1:aJcP4gqTC2vLW6c/ZktcAIjzm31unnCRTNi2VZkLDIU=
-github.com/openshift/coredns-ocp-dnsnameresolver/operator v0.0.0-20240514135022-c41cdd134379/go.mod h1:k0W4ol96vtJ9XtOU1cLzHci9biisZf0CflX+Pj3F1V8=
+github.com/openshift/coredns-ocp-dnsnameresolver/operator v0.0.0-20240712094134-af651cec05d1 h1:3R+zdOclUXVxpewmSGgAKPUNLFGRFhTpaarOxVhPkww=
+github.com/openshift/coredns-ocp-dnsnameresolver/operator v0.0.0-20240712094134-af651cec05d1/go.mod h1:xr33hQoeI2qcehK9kYPm9V86CTumVN/sdDOGdxw10Xg=
 github.com/openshift/library-go v0.0.0-20231102154438-cfcf2b4fbc87 h1:GcaI98ric0Q3WbZsTh8cIE39pgw12v3s3xuiIFO5zQ0=
 github.com/openshift/library-go v0.0.0-20231102154438-cfcf2b4fbc87/go.mod h1:8UzmrBMCn7+GzouL8DVYkL9COBQTB1Ggd13/mHJQCUg=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/pkg/operator/controller/controller_cluster_role.go
+++ b/pkg/operator/controller/controller_cluster_role.go
@@ -63,12 +63,12 @@ func addDNSNameResolverPolicyRule(cr *rbacv1.ClusterRole) {
 	cr.Rules = append(cr.Rules, rbacv1.PolicyRule{
 		APIGroups: []string{"network.openshift.io"},
 		Resources: []string{"dnsnameresolvers"},
-		Verbs:     []string{"list", "watch"},
+		Verbs:     []string{"get", "list", "watch"},
 	})
 	cr.Rules = append(cr.Rules, rbacv1.PolicyRule{
 		APIGroups: []string{"network.openshift.io"},
 		Resources: []string{"dnsnameresolvers/status"},
-		Verbs:     []string{"update"},
+		Verbs:     []string{"get", "update", "patch"},
 	})
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -212,7 +212,7 @@ github.com/openshift/client-go/config/informers/externalversions/config/v1alpha1
 github.com/openshift/client-go/config/informers/externalversions/internalinterfaces
 github.com/openshift/client-go/config/listers/config/v1
 github.com/openshift/client-go/config/listers/config/v1alpha1
-# github.com/openshift/coredns-ocp-dnsnameresolver/operator v0.0.0-20240514135022-c41cdd134379
+# github.com/openshift/coredns-ocp-dnsnameresolver/operator v0.0.0-20240712094134-af651cec05d1
 ## explicit; go 1.21
 github.com/openshift/coredns-ocp-dnsnameresolver/operator/controller/dnsnameresolver
 # github.com/openshift/library-go v0.0.0-20231102154438-cfcf2b4fbc87


### PR DESCRIPTION
This PR bumps the version of the the DNSNameResolver controller. This PR also adds the additional RBAC permissions required by the CoreDNS pods for the DNSNameResolver CRs.