### PR TITLE
[WIP] OCPBUGS-31351: Minimize wildcard privileges for nodes and namespaces

### DIFF
--- a/manifests/0000_70_dns-operator_00-cluster-role.yaml
+++ b/manifests/0000_70_dns-operator_00-cluster-role.yaml
@@ -39,7 +39,24 @@ rules:
   - configmaps
   - endpoints
   - pods
+  verbs:
+  - "*"
+
+- apiGroups:
+  - ""
+  resources:
   - nodes
+  verbs:
+  - get
+  - list
+  - watch
+
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  resourceNames:
+  - openshift-dns
   verbs:
   - "*"
 


### PR DESCRIPTION
- Restricted wildcard namespace permissions exclusively to operand namespace.
- Scoped node permissions to readonly to enable infromer watches.