### PR TITLE
OCPBUGS-45338: dns-default daemonset should run everywhere

### DIFF
--- a/pkg/operator/controller/controller_dns_daemonset.go
+++ b/pkg/operator/controller/controller_dns_daemonset.go
@@ -201,7 +201,6 @@ func tolerationsForDNS(dns *operatorv1.DNS) []corev1.Toleration {
 		return dns.Spec.NodePlacement.Tolerations
 	}
 	return []corev1.Toleration{{
-		Key:      "node-role.kubernetes.io/master",
 		Operator: corev1.TolerationOpExists,
 	}}
 }

--- a/pkg/operator/controller/controller_dns_daemonset_test.go
+++ b/pkg/operator/controller/controller_dns_daemonset_test.go
@@ -55,7 +55,6 @@ func TestDesiredDNSDaemonset(t *testing.T) {
 		}
 		actualTolerations := ds.Spec.Template.Spec.Tolerations
 		expectedTolerations := []corev1.Toleration{{
-			Key:      "node-role.kubernetes.io/master",
 			Operator: corev1.TolerationOpExists,
 		}}
 		if !reflect.DeepEqual(actualPodAnnotations, expectedPodAnnotations) {


### PR DESCRIPTION
Managed services marks a couple of nodes as
"infra" so user workloads don't get scheduled on
them.  However, platform daemonsets like dns
should run there – and the typical toleration for
that purpose should be:

```yaml
tolerations:
- operator: Exists
```

instead the dns-default toleration is

```yaml
tolerations:
- key: "node-role.kubernetes.io/master"
  operator: "Exists"
  effect: "NoSchedule"
```

There's only two daemonsets that don't follow this pattern (iptables-alerter and dns-default) and it's causing issues in CI runs for ROSA.  The PreferredDuringScheduling doesn't actually guarantee the taints are obeyed, sometimes these DS end up on an infra node and then KubeDaemonSetMisScheduled fires (and fails the CI run).

Examples showing this is how other DS implement it:

```
$ for ns in openshift-cluster-csi-drivers openshift-cluster-node-tuning-operator openshift-dns openshift-image-registry openshift-machine-config-operator openshift-monitoring openshift-multus openshift-multus openshift-multus openshift-network-diagnostics openshift-network-operator openshift-ovn-kubernetes openshift-security; do echo "NS: $ns"; oc get ds -o json -n $ns|jq '.items.[0].spec.template.spec.tolerations'; done
NS: openshift-cluster-csi-drivers
[
  {
    "operator": "Exists"
  }
]
NS: openshift-cluster-node-tuning-operator
[
  {
    "operator": "Exists"
  }
]
NS: openshift-dns
[
  {
    "key": "node-role.kubernetes.io/master",
    "operator": "Exists"
  }
]
NS: openshift-image-registry
[
  {
    "operator": "Exists"
  }
]
NS: openshift-machine-config-operator
[
  {
    "operator": "Exists"
  }
]
NS: openshift-monitoring
[
  {
    "operator": "Exists"
  }
]
NS: openshift-multus
[
  {
    "operator": "Exists"
  }
]
NS: openshift-multus
[
  {
    "operator": "Exists"
  }
]
NS: openshift-multus
[
  {
    "operator": "Exists"
  }
]
NS: openshift-network-diagnostics
[
  {
    "operator": "Exists"
  }
]
NS: openshift-network-operator
[
  {
    "effect": "NoSchedule",
    "key": "node-role.kubernetes.io/master",
    "operator": "Exists"
  }
]
NS: openshift-ovn-kubernetes
[
  {
    "operator": "Exists"
  }
]
NS: openshift-security
[
  {
    "operator": "Exists"
  }
]
```