### PR TITLE
Implements https://issues.redhat.com/browse/OCPSTRAT-2006

### DIFF
--- a/manifests/0000_70_dns-operator_00.crd.yaml
+++ b/manifests/0000_70_dns-operator_00.crd.yaml
@@ -87,6 +87,11 @@ spec:
                     pattern: ^(0|([0-9]+(\.[0-9]+)?(ns|us|µs|μs|ms|s|m|h))+)$
                     type: string
                 type: object
+              ipv6Filter:
+                default: false
+                description: 'IPv6Filter, if true, disables AAAA responses using a
+                  CoreDNS template block.'
+                type: boolean
               logLevel:
                 default: Normal
                 description: 'logLevel describes the desired logging verbosity for

--- a/pkg/operator/controller/controller_dns_configmap.go
+++ b/pkg/operator/controller/controller_dns_configmap.go
@@ -73,6 +73,11 @@ var corefileTemplate = template.Must(template.New("Corefile").Funcs(template.Fun
         namespaces {{range $.DNSNameResolverNamespaces}}{{.}} {{end}}
     }
     {{- end}}
+    {{- if $.IPv6Filter}}
+    template ANY AAAA {
+        rcode NOERROR
+    }
+    {{- end}}
 }
 {{end -}}
 .:5353 {
@@ -111,6 +116,11 @@ var corefileTemplate = template.Must(template.New("Corefile").Funcs(template.Fun
     {{- if eq true $.OCPDNSNameResolver}}
     ocp_dnsnameresolver {
         namespaces {{range $.DNSNameResolverNamespaces}}{{.}} {{end}}
+    }
+    {{- end}}
+    {{- if .IPv6Filter}}
+    template ANY AAAA {
+        rcode NOERROR
     }
     {{- end}}
 }
@@ -218,6 +228,7 @@ func desiredDNSConfigMap(dns *operatorv1.DNS, clusterDomain string, caBundleRevi
 		NegativeTTL               uint32
 		OCPDNSNameResolver        bool
 		DNSNameResolverNamespaces []string
+		IPv6Filter                bool
 	}{
 		ClusterDomain:             clusterDomain,
 		Servers:                   dns.Spec.Servers,
@@ -231,6 +242,7 @@ func desiredDNSConfigMap(dns *operatorv1.DNS, clusterDomain string, caBundleRevi
 		NegativeTTL:               nTTL,
 		OCPDNSNameResolver:        dnsNameResolverEnabled,
 		DNSNameResolverNamespaces: dnsNameResolverNamespaces,
+		IPv6Filter:                dns.Spec.IPv6Filter,
 	}
 	corefile := new(bytes.Buffer)
 	if err := corefileTemplate.Execute(corefile, corefileParameters); err != nil {

--- a/pkg/operator/controller/controller_dns_configmap_test.go
+++ b/pkg/operator/controller/controller_dns_configmap_test.go
@@ -220,6 +220,18 @@ func TestDesiredDNSConfigmap(t *testing.T) {
 			},
 			expectedCoreFile: mustLoadTestFile(t, "default_corefile_cache_with_fractional_values_configured"),
 		},
+		{
+			name: "Check if IPv6Filter adds template block",
+			dns: &operatorv1.DNS{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: DefaultDNSController,
+				},
+				Spec: operatorv1.DNSSpec{
+					IPv6Filter: true,
+				},
+			},
+			expectedCoreFile: mustLoadTestFile(t, "ipv6filter_corefile"),
+		},
 	}
 
 	clusterDomain := "cluster.local"

--- a/pkg/operator/controller/testdata/ipv6filter_corefile
+++ b/pkg/operator/controller/testdata/ipv6filter_corefile
@@ -1,0 +1,29 @@
+.:5353 {
+    bufsize 1232
+    errors
+    log . {
+        class error
+    }
+    health {
+        lameduck 20s
+    }
+    ready
+    kubernetes cluster.local in-addr.arpa ip6.arpa {
+        pods insecure
+        fallthrough in-addr.arpa ip6.arpa
+    }
+    prometheus 127.0.0.1:9153
+    forward . /etc/resolv.conf {
+        policy sequential
+    }
+    cache 900 {
+        denial 9984 30
+    }
+    reload
+    template ANY AAAA {
+        rcode NOERROR
+    }
+}
+hostname.bind:5353 {
+    chaos
+}

--- a/vendor/github.com/openshift/api/operator/v1/types_dns.go
+++ b/vendor/github.com/openshift/api/operator/v1/types_dns.go
@@ -116,6 +116,9 @@ type DNSSpec struct {
 	// 30 seconds or as noted in the respective Corefile for your version of OpenShift.
 	// +optional
 	Cache DNSCache `json:"cache,omitempty"`
+
+	// IPv6Filter, if true, disables AAAA responses using a CoreDNS template block.
+	IPv6Filter bool `json:"ipv6Filter,omitempty"`
 }
 
 // DNSCache defines the fields for configuring DNS caching.

--- a/vendor/github.com/openshift/api/operator/v1/zz_generated.crd-manifests/0000_70_dns_00_dnses.crd.yaml
+++ b/vendor/github.com/openshift/api/operator/v1/zz_generated.crd-manifests/0000_70_dns_00_dnses.crd.yaml
@@ -87,6 +87,11 @@ spec:
                     pattern: ^(0|([0-9]+(\.[0-9]+)?(ns|us|µs|μs|ms|s|m|h))+)$
                     type: string
                 type: object
+              ipv6Filter:
+                default: false
+                description: 'IPv6Filter, if true, disables AAAA responses using a
+                  CoreDNS template block.'
+                type: boolean
               logLevel:
                 default: Normal
                 description: 'logLevel describes the desired logging verbosity for


### PR DESCRIPTION
This commit adds a new ipv6Filter parameter to the DNS Custom Resource Definition (CRD), defaulting to false. When enabled (true), it returns a NOERROR response with an empty answer section, effectively suppressing IPv6 query propagation to upstream DNS servers when desired.

Use with caution, as it may introduce unintended side effects.