### PR TITLE
RFE-4145: Support custom list of services to be added to /etc/hosts by Node resolver

### DIFF
--- a/manifests/0000_70_dns-operator_00.crd.yaml
+++ b/manifests/0000_70_dns-operator_00.crd.yaml
@@ -188,6 +188,13 @@ spec:
                 - Debug
                 - Trace
                 type: string
+              additionalServices:
+                description: 'additionalServices specifies additional services for which entries should be added to /etc/hosts by the node resolver. These services will be added in addition to the default "image-registry.openshift-image-registry.svc" service. Each service should be a relative name following the format "<service>.<namespace>.svc"; for each relative name, an alias with the CLUSTER_DOMAIN suffix will also be added.'
+                items:
+                  pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?\.[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.svc)?$'
+                  type: string
+                maxItems: 20
+                type: array
               servers:
                 description: "servers is a list of DNS resolvers that provide name
                   query delegation for one or more subdomains outside the scope of

--- a/pkg/operator/controller/controller_dns_node_resolver_daemonset.go
+++ b/pkg/operator/controller/controller_dns_node_resolver_daemonset.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -23,11 +24,9 @@ import (
 )
 
 const (
-	// services is a comma- or space-delimited list of services for which
-	// entries should be added to /etc/hosts.  NOTE: For now, ensure these
-	// are relative names; for each relative name, an alias with the
-	// CLUSTER_DOMAIN suffix will also be added.
-	services = "image-registry.openshift-image-registry.svc"
+	// defaultService is the default service that should always be included
+	// in the services list for the node resolver
+	defaultService = "image-registry.openshift-image-registry.svc"
 
 	// workloadPartitioningManagement contains the management workload annotation
 	workloadPartitioningManagement = "target.workload.openshift.io/management"
@@ -37,6 +36,26 @@ var (
 	// nodeResolverScript is a shell script that updates /etc/hosts.
 	nodeResolverScript = manifests.NodeResolverScript()
 )
+
+// buildServicesList combines the default service with additional services from the DNS spec.
+// The default service is always included first, followed by any additional services.
+func buildServicesList(dns *operatorv1.DNS) string {
+	// Start with the default service
+	services := []string{defaultService}
+
+	// Add any additional services from the spec
+	if len(dns.Spec.AdditionalServices) > 0 {
+		for _, service := range dns.Spec.AdditionalServices {
+			// Trim whitespace and add non-empty services
+			if trimmed := strings.TrimSpace(service); trimmed != "" {
+				services = append(services, trimmed)
+			}
+		}
+	}
+
+	// Join all services with commas for the environment variable
+	return strings.Join(services, ",")
+}
 
 // ensureNodeResolverDaemonset ensures the node resolver daemonset exists if it
 // should or does not exist if it should not exist.  Returns a Boolean
@@ -82,7 +101,7 @@ func desiredNodeResolverDaemonSet(dns *operatorv1.DNS, clusterIP, clusterDomain,
 	maxUnavailable := intstr.FromString("33%")
 	envs := []corev1.EnvVar{{
 		Name:  "SERVICES",
-		Value: services,
+		Value: buildServicesList(dns),
 	}}
 	if len(clusterIP) > 0 {
 		envs = append(envs, corev1.EnvVar{

--- a/pkg/operator/controller/controller_dns_node_resolver_daemonset_test.go
+++ b/pkg/operator/controller/controller_dns_node_resolver_daemonset_test.go
@@ -12,6 +12,81 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
+// TestBuildServicesList tests the buildServicesList function with various DNS configurations
+func TestBuildServicesList(t *testing.T) {
+	testCases := []struct {
+		name               string
+		additionalServices []string
+		expected           string
+	}{
+		{
+			name:               "no additional services",
+			additionalServices: nil,
+			expected:           "image-registry.openshift-image-registry.svc",
+		},
+		{
+			name:               "empty additional services slice",
+			additionalServices: []string{},
+			expected:           "image-registry.openshift-image-registry.svc",
+		},
+		{
+			name:               "single additional service",
+			additionalServices: []string{"my-service.my-namespace.svc"},
+			expected:           "image-registry.openshift-image-registry.svc,my-service.my-namespace.svc",
+		},
+		{
+			name:               "multiple additional services",
+			additionalServices: []string{"service1.namespace1.svc", "service2.namespace2.svc", "service3.namespace3.svc"},
+			expected:           "image-registry.openshift-image-registry.svc,service1.namespace1.svc,service2.namespace2.svc,service3.namespace3.svc",
+		},
+		{
+			name:               "service with whitespace gets trimmed",
+			additionalServices: []string{"  my-service.my-namespace.svc  "},
+			expected:           "image-registry.openshift-image-registry.svc,my-service.my-namespace.svc",
+		},
+		{
+			name:               "mixed clean and whitespace services",
+			additionalServices: []string{"service1.namespace1.svc", "  service2.namespace2.svc  ", "service3.namespace3.svc"},
+			expected:           "image-registry.openshift-image-registry.svc,service1.namespace1.svc,service2.namespace2.svc,service3.namespace3.svc",
+		},
+		{
+			name:               "empty string services are filtered out",
+			additionalServices: []string{"service1.namespace1.svc", "", "service2.namespace2.svc"},
+			expected:           "image-registry.openshift-image-registry.svc,service1.namespace1.svc,service2.namespace2.svc",
+		},
+		{
+			name:               "whitespace-only services are filtered out",
+			additionalServices: []string{"service1.namespace1.svc", "   ", "service2.namespace2.svc"},
+			expected:           "image-registry.openshift-image-registry.svc,service1.namespace1.svc,service2.namespace2.svc",
+		},
+		{
+			name:               "all whitespace/empty services filtered out",
+			additionalServices: []string{"", "   ", "\t"},
+			expected:           "image-registry.openshift-image-registry.svc",
+		},
+		{
+			name:               "service without .svc suffix",
+			additionalServices: []string{"my-service.my-namespace"},
+			expected:           "image-registry.openshift-image-registry.svc,my-service.my-namespace",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dns := &operatorv1.DNS{
+				Spec: operatorv1.DNSSpec{
+					AdditionalServices: tc.additionalServices,
+				},
+			}
+
+			result := buildServicesList(dns)
+			if result != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, result)
+			}
+		})
+	}
+}
+
 // TestDesiredNodeResolverDaemonset verifies that desiredNodeResolverDaemonSet
 // returns the expected daemonset.
 func TestDesiredNodeResolverDaemonset(t *testing.T) {
@@ -53,6 +128,79 @@ func TestDesiredNodeResolverDaemonset(t *testing.T) {
 		} else if clusterDomain != domain {
 			t.Errorf("expected CLUSTER_DOMAIN env for dns node resolver image %q, got %q", clusterDomain, domain)
 		}
+		services, ok := envs["SERVICES"]
+		if !ok {
+			t.Errorf("SERVICES env for dns node resolver image not found")
+		} else if services != "image-registry.openshift-image-registry.svc" {
+			t.Errorf("expected SERVICES env for dns node resolver image %q, got %q", "image-registry.openshift-image-registry.svc", services)
+		}
+	}
+}
+
+// TestDesiredNodeResolverDaemonsetWithAdditionalServices verifies that desiredNodeResolverDaemonSet
+// correctly handles additional services in the SERVICES environment variable.
+func TestDesiredNodeResolverDaemonsetWithAdditionalServices(t *testing.T) {
+	clusterDomain := "cluster.local"
+	clusterIP := "172.30.77.10"
+	openshiftCLIImage := "openshift/origin-cli:test"
+
+	testCases := []struct {
+		name               string
+		additionalServices []string
+		expectedServices   string
+	}{
+		{
+			name:               "with single additional service",
+			additionalServices: []string{"my-api.my-namespace.svc"},
+			expectedServices:   "image-registry.openshift-image-registry.svc,my-api.my-namespace.svc",
+		},
+		{
+			name:               "with multiple additional services",
+			additionalServices: []string{"service1.ns1.svc", "service2.ns2.svc"},
+			expectedServices:   "image-registry.openshift-image-registry.svc,service1.ns1.svc,service2.ns2.svc",
+		},
+		{
+			name:               "with services containing whitespace",
+			additionalServices: []string{"  clean-service.namespace.svc  ", "another-service.ns.svc"},
+			expectedServices:   "image-registry.openshift-image-registry.svc,clean-service.namespace.svc,another-service.ns.svc",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dns := &operatorv1.DNS{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: DefaultDNSController,
+				},
+				Spec: operatorv1.DNSSpec{
+					AdditionalServices: tc.additionalServices,
+				},
+			}
+
+			if want, ds, err := desiredNodeResolverDaemonSet(dns, clusterIP, clusterDomain, openshiftCLIImage); err != nil {
+				t.Errorf("invalid node resolver daemonset: %v", err)
+			} else if !want {
+				t.Error("expected the node resolver daemonset desired to be true, got false")
+			} else if len(ds.Spec.Template.Spec.Containers) != 1 {
+				t.Errorf("expected number of daemonset containers 1, got %d", len(ds.Spec.Template.Spec.Containers))
+			} else {
+				c := ds.Spec.Template.Spec.Containers[0]
+
+				// Check environment variables
+				envs := map[string]string{}
+				for _, e := range c.Env {
+					envs[e.Name] = e.Value
+				}
+
+				// Verify SERVICES environment variable contains expected services
+				services, ok := envs["SERVICES"]
+				if !ok {
+					t.Errorf("SERVICES env for dns node resolver image not found")
+				} else if services != tc.expectedServices {
+					t.Errorf("expected SERVICES env for dns node resolver image %q, got %q", tc.expectedServices, services)
+				}
+			}
+		})
 	}
 }
 

--- a/vendor/github.com/openshift/api/operator/v1/types_dns.go
+++ b/vendor/github.com/openshift/api/operator/v1/types_dns.go
@@ -95,6 +95,17 @@ type DNSSpec struct {
 	// +kubebuilder:default=Normal
 	OperatorLogLevel DNSLogLevel `json:"operatorLogLevel,omitempty"`
 
+	// additionalServices specifies additional services for which entries should be added
+	// to /etc/hosts by the node resolver. These services will be added in addition to
+	// the default "image-registry.openshift-image-registry.svc" service.
+	// Each service should be a relative name following the format "<service>.<namespace>.svc";
+	// for each relative name, an alias with the CLUSTER_DOMAIN suffix will also be added.
+	//
+	// +optional
+	// +kubebuilder:validation:MaxItems=20
+	// +kubebuilder:validation:items:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?\.[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.svc)?$`
+	AdditionalServices []string `json:"additionalServices,omitempty"`
+
 	// logLevel describes the desired logging verbosity for CoreDNS.
 	// Any one of the following values may be specified:
 	// * Normal logs errors from upstream resolvers.

--- a/vendor/github.com/openshift/api/operator/v1/zz_generated.crd-manifests/0000_70_dns_00_dnses.crd.yaml
+++ b/vendor/github.com/openshift/api/operator/v1/zz_generated.crd-manifests/0000_70_dns_00_dnses.crd.yaml
@@ -188,6 +188,13 @@ spec:
                 - Debug
                 - Trace
                 type: string
+              additionalServices:
+                description: 'additionalServices specifies additional services for which entries should be added to /etc/hosts by the node resolver. These services will be added in addition to the default "image-registry.openshift-image-registry.svc" service. Each service should be a relative name following the format "<service>.<namespace>.svc"; for each relative name, an alias with the CLUSTER_DOMAIN suffix will also be added.'
+                items:
+                  pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?\.[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.svc)?$'
+                  type: string
+                maxItems: 20
+                type: array
               servers:
                 description: "servers is a list of DNS resolvers that provide name
                   query delegation for one or more subdomains outside the scope of


### PR DESCRIPTION
Today, node-resolver daemonset in openshift-dns-operator namespace is referencing a SERVICES environment variable allowing to update /etc/hosts of all nodes of the cluster with entries for custom services of the platform, so it can be targeted directly from nodes. This allow the nodes to have access to internal openshift registry directly using DNS entry image-registry.openshift-image-registry.svc
Only issue is that this value for _SERVICES_ env variable is harcoded in cluster-dns-operator code, so it does not allow to reference other services available also at node level.

This PR update DNS operator.openshift.io custom resource and associated controller to support a list of openshift services so they will be added automatically in /etc/hosts and available on all cluster nodes.

This is tracked by [RFE-4145](https://issues.redhat.com/browse/RFE-4145)