### PR TITLE
OCPBUGS-59781: Read only root filesystem

### DIFF
--- a/pkg/manifests/assets/dns/daemonset.yaml
+++ b/pkg/manifests/assets/dns/daemonset.yaml
@@ -79,6 +79,8 @@ spec:
           readOnly: true
         - mountPath: /tmp
           name: tmp-dir
+        securityContext:
+          readOnlyRootFilesystem: true
       dnsPolicy: Default
       # nodeSelector is set at runtime.
       volumes:


### PR DESCRIPTION
Missed the kube-rbac-proxy container in #439 