### PR TITLE
NOJIRA: Add a govulncheck make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,3 +85,18 @@ run-local: build
 clean:
 	$(GO) clean
 	rm -f $(BIN)
+
+LOCALBIN ?= $(shell pwd)/tmp
+GOVULNCHECK = $(LOCALBIN)/govulncheck
+
+.PHONY: vulncheck
+vulncheck: $(GOVULNCHECK)
+	$(GOVULNCHECK) ./...
+
+# Dependencies / Tools specifics
+
+$(LOCALBIN):
+	[ -d $@ ] || mkdir -p $@
+
+$(GOVULNCHECK): $(LOCALBIN)
+	GOBIN=$(LOCALBIN) go install golang.org/x/vuln/cmd/govulncheck@latest


### PR DESCRIPTION
This change adds a govulncheck Makefile target.

Using this target, one can do `make vulncheck` that will install and run the `govulncheck` against the project source and verify if any part of it is consuming a vulnerable library.