### PR TITLE
CNTRLPLANE-1544: pkg/manifests: Enable user namespaces

### DIFF
--- a/pkg/manifests/assets/dns/daemonset.yaml
+++ b/pkg/manifests/assets/dns/daemonset.yaml
@@ -11,6 +11,13 @@ spec:
     spec:
       serviceAccountName: dns
       priorityClassName: system-node-critical
+      hostUsers: false
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: dns
         # image is set at runtime
@@ -56,6 +63,10 @@ spec:
             memory: 70Mi
         securityContext:
           readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
       - name: kube-rbac-proxy
         # image is set at runtime
         args:


### PR DESCRIPTION
This updates the DaemonSet manifests to enable user namespaces and also restrict the DS so that it is aligned with restricted-v3 scc policy.