### PR TITLE
OCPBUGS-77532: Fix premature node schedulability marking in taint checking

### DIFF
--- a/pkg/operator/controller/controller_dns_daemonset.go
+++ b/pkg/operator/controller/controller_dns_daemonset.go
@@ -401,17 +401,19 @@ func (r *reconciler) daemonsetUpdateIsSafe(current, updated *appsv1.DaemonSet) (
 }
 
 func tolerationsTolerateTaints(tolerations []corev1.Toleration, taints []corev1.Taint) bool {
-	if len(taints) == 0 {
-		return true
-	}
 	for _, taint := range taints {
+		tolerated := false
 		for _, toleration := range tolerations {
 			if toleration.ToleratesTaint(logr.Discard(), &taint, false) {
-				return true
+				tolerated = true
+				break
 			}
 		}
+		if !tolerated {
+			return false
+		}
 	}
-	return false
+	return true
 }
 
 // daemonsetConfigChanged checks if current config matches the expected config

--- a/pkg/operator/controller/controller_dns_daemonset_test.go
+++ b/pkg/operator/controller/controller_dns_daemonset_test.go
@@ -823,3 +823,88 @@ func TestDesiredDNSDaemonSetTLSArgs(t *testing.T) {
 		}
 	}
 }
+
+func TestTolerationsTolerateTaints(t *testing.T) {
+	tests := []struct {
+		name        string
+		tolerations []corev1.Toleration
+		taints      []corev1.Taint
+		expect      bool
+	}{
+		{
+			name:        "no taints",
+			tolerations: []corev1.Toleration{{Key: "node-role.kubernetes.io/master", Operator: corev1.TolerationOpExists}},
+			taints:      []corev1.Taint{},
+			expect:      true,
+		},
+		{
+			name: "single taint tolerated",
+			tolerations: []corev1.Toleration{
+				{Key: "node-role.kubernetes.io/master", Operator: corev1.TolerationOpExists},
+			},
+			taints: []corev1.Taint{
+				{Key: "node-role.kubernetes.io/master", Effect: corev1.TaintEffectNoSchedule},
+			},
+			expect: true,
+		},
+		{
+			name:        "single taint not tolerated",
+			tolerations: []corev1.Toleration{},
+			taints: []corev1.Taint{
+				{Key: "node-role.kubernetes.io/master", Effect: corev1.TaintEffectNoSchedule},
+			},
+			expect: false,
+		},
+		{
+			name: "multiple taints all tolerated",
+			tolerations: []corev1.Toleration{
+				{Key: "node-role.kubernetes.io/master", Operator: corev1.TolerationOpExists},
+				{Key: "node.kubernetes.io/disk-pressure", Operator: corev1.TolerationOpExists},
+			},
+			taints: []corev1.Taint{
+				{Key: "node-role.kubernetes.io/master", Effect: corev1.TaintEffectNoSchedule},
+				{Key: "node.kubernetes.io/disk-pressure", Effect: corev1.TaintEffectNoSchedule},
+			},
+			expect: true,
+		},
+		{
+			name: "multiple taints only some tolerated",
+			tolerations: []corev1.Toleration{
+				{Key: "node-role.kubernetes.io/master", Operator: corev1.TolerationOpExists},
+			},
+			taints: []corev1.Taint{
+				{Key: "node-role.kubernetes.io/master", Effect: corev1.TaintEffectNoSchedule},
+				{Key: "node.kubernetes.io/disk-pressure", Effect: corev1.TaintEffectNoSchedule},
+			},
+			expect: false,
+		},
+		{
+			name:        "multiple taints none tolerated",
+			tolerations: []corev1.Toleration{},
+			taints: []corev1.Taint{
+				{Key: "node-role.kubernetes.io/master", Effect: corev1.TaintEffectNoSchedule},
+				{Key: "node.kubernetes.io/disk-pressure", Effect: corev1.TaintEffectNoSchedule},
+			},
+			expect: false,
+		},
+		{
+			name: "wildcard toleration tolerates all taints",
+			tolerations: []corev1.Toleration{
+				{Operator: corev1.TolerationOpExists},
+			},
+			taints: []corev1.Taint{
+				{Key: "node-role.kubernetes.io/infra", Effect: corev1.TaintEffectNoSchedule},
+				{Key: "node.kubernetes.io/not-ready", Effect: corev1.TaintEffectNoExecute},
+			},
+			expect: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tolerationsTolerateTaints(tc.tolerations, tc.taints)
+			if got != tc.expect {
+				t.Errorf("expected %v, got %v", tc.expect, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Fix `tolerationsTolerateTaints()` to require **all** taints on a node to be tolerated (not just any one) before considering the node schedulable
- Add comprehensive unit tests for the taint-toleration matching logic

## Context

The `tolerationsTolerateTaints` function in `daemonsetUpdateIsSafe` was returning `true` as soon as it found any single taint tolerated by any toleration. This meant a node with multiple taints (e.g. `node-role.kubernetes.io/master` and `node.kubernetes.io/disk-pressure`) would be considered schedulable even if only the master taint was tolerated, violating standard Kubernetes scheduling semantics.

The fix ensures every taint on a node must be tolerated by at least one toleration before returning `true`.

See also: https://github.com/openshift/cluster-dns-operator/pull/459#pullrequestreview-3875844118

## Test plan

- [x] Unit tests added for `tolerationsTolerateTaints` covering:
  - No taints (returns true)
  - Single taint tolerated / not tolerated
  - Multiple taints: all tolerated, only some tolerated (bug scenario), none tolerated
  - Wildcard toleration matching all taints
- [x] `make build` passes
- [x] `make test` passes
- [x] `make verify` passes

🤖 Assisted by [Claude Code](https://claude.com/claude-code) via `/jira:solve OCPBUGS-77532`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected taint tolerance evaluation for DNS DaemonSet pod scheduling to ensure accurate assessment of node compatibility.

* **Tests**
  * Added comprehensive test coverage for taint tolerance validation across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->