### PR TITLE
NE-2391: Add progressive disclosure AI agent context

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1,0 +1,36 @@
+# Cluster DNS Operator Architecture
+
+The OpenShift Cluster DNS Operator manages the DNS lifecycle within an OpenShift cluster. 
+
+## Core Components
+
+1. **DNS Operator**: Runs in the `openshift-dns-operator` namespace. It watches the `dns.operator.openshift.io/default` custom resource (CR).
+2. **CoreDNS (Operand)**: The Operator deploys CoreDNS as a **DaemonSet** (`dns-default`) in the `openshift-dns` namespace. This ensures a local CoreDNS pod runs on every cluster node for maximum scalability and low-latency local resolution.
+3. **ClusterIP Service**: A service (typically `dns-default`) provides a stable ClusterIP (e.g., `172.30.0.10`). The Kubelet configures pods to use this IP for resolution.
+4. **ConfigMap (Corefile)**: The DNS Operator manages the `Corefile` configuration via a ConfigMap, which includes plugins for kubernetes service discovery, external forwarding, metrics, and caching.
+
+## How Pods Resolve DNS
+
+When a new Pod is created, the Kubelet automatically injects DNS configuration into the Pod's `/etc/resolv.conf`:
+1.  **Pod configuration:** The primary nameserver points to the `dns-default` service ClusterIP (typically `172.30.0.10`). The default `dnsPolicy` is `ClusterFirst`.
+2.  **Search domains:** Includes domains like `<namespace>.svc.cluster.local`, `svc.cluster.local`, and `cluster.local`, enabling short-name resolution (e.g., `my-service` resolves to `my-service.my-namespace.svc.cluster.local`).
+3.  **Routing optimization:** Because CoreDNS runs as a DaemonSet, OVN-Kubernetes preferentially routes DNS queries to the local CoreDNS pod on the same node, minimizing latency.
+4.  **Resolution Flow:**
+    - **Internal:** CoreDNS uses the `kubernetes` plugin to resolve cluster-internal names (`*.cluster.local`).
+    - **External:** Queries outside the cluster domain are handled by the `forward` plugin, relying on the upstream nameservers defined in the node's `/etc/resolv.conf`.
+
+## Advanced Integrations
+
+*   **Node Resolver DaemonSet:** Managed by the operator, this DaemonSet runs on every node to look up the ClusterIP of the internal image registry (`image-registry.openshift-image-registry.svc`) and writes it into the node's `/etc/hosts` file. This resolves the bootstrapping chicken-and-egg problem where the node's container runtime needs to pull images before cluster DNS is fully operational.
+*   **On-Premise Platforms (MCO Layer):** On bare metal, vSphere, and OpenStack, there's an additional CoreDNS instance managed by the Machine Config Operator (MCO) running as static pods on nodes. These handle node-level DNS (e.g., resolving `api-int` records) and delegate cluster-related lookups to the main CoreDNS service in `openshift-dns`.
+
+## Key Resources Summary
+
+| Namespace | Resource | Purpose |
+| :--- | :--- | :--- |
+| `openshift-dns-operator` | Deployment/dns-operator | The Cluster DNS Operator |
+| `openshift-dns` | DaemonSet/dns-default | CoreDNS pods (one per node) |
+| `openshift-dns` | Service/dns-default | Stable ClusterIP for DNS |
+| `openshift-dns` | ConfigMap/dns-default | The generated Corefile |
+| `openshift-dns` | DaemonSet/node-resolver | `/etc/hosts` updater for nodes |
+| `(Cluster Scoped)` | CR `dns.operator.openshift.io/default` | The DNS configuration CR |

--- a/.agents/context.md
+++ b/.agents/context.md
@@ -1,0 +1,13 @@
+# OpenShift Networking Context: DNS Operator & CoreDNS
+
+This document provides a high-level overview of how the `cluster-dns-operator` and its operand, `CoreDNS`, fit into the broader OpenShift Networking architecture. This context is critical for understanding the impact of changes made within this repository.
+
+## The Big Picture: Operator vs. Operand vs. CNI
+
+In OpenShift, network connectivity and service discovery are handled by a layered architecture. CoreDNS and the Cluster DNS Operator are distinct components with separate Git repositories, but they work together as a single integrated DNS system:
+
+*   **OVN-Kubernetes (The CNI / The Wires):** The default Container Network Interface (CNI). It uses Open Virtual Network (OVN) and Open vSwitch (OVS) to create the software-defined overlay network, providing routing, switching, and encapsulation.
+*   **Cluster DNS Operator (The Manager):** This repository (`openshift/cluster-dns-operator`). It lives in the `openshift-dns-operator` namespace as a Deployment. It is the control plane that automates the deployment, configuration, and lifecycle of the DNS infrastructure.
+*   **CoreDNS (The Directory / The Operand):** The actual DNS server implementation (`openshift/coredns`). The operator deploys it as a DaemonSet (`dns-default`) in the `openshift-dns` namespace to ensure every node has a local resolver. OVN-Kubernetes routes DNS queries from pods to these local CoreDNS instances.
+
+*Note: The owning team for both DNS components is Network Ingress and DNS.*

--- a/.agents/controllers.md
+++ b/.agents/controllers.md
@@ -1,0 +1,39 @@
+# Controller Patterns in cluster-dns-operator
+
+The business logic resides primarily in `pkg/operator/controller/`. The operator is built on `controller-runtime` and follows the standard operator pattern.
+
+## The Custom Resource: The Single Source of Truth
+
+Everything starts with a single Custom Resource:
+```yaml
+apiVersion: operator.openshift.io/v1
+kind: DNS
+metadata:
+  name: default
+```
+This CR is the single source of truth for how DNS should behave in the cluster. Administrators configure upstream resolvers, per-zone forwarding rules, cache TTLs, node placement, and more by editing this CR. The operator watches it and reconciles the cluster state to match.
+
+## Operator Reconciliation: From CR to Corefile
+
+### Key controllers:
+*   `controller.go`: Main reconciler; sets up watches on DNS CR, DaemonSets, Services, and ConfigMaps.
+*   `controller_dns_configmap.go`: Generates the Corefile from a Go template and stores it in a ConfigMap.
+*   `controller_dns_daemonset.go`: Manages the CoreDNS DaemonSet.
+*   `controller_dns_service.go`: Manages the `dns-default` Kubernetes Service.
+*   `controller_dns_node_resolver_daemonset.go`: Manages the `node-resolver` DaemonSet.
+*   `dns_status.go`: Updates the ClusterOperator status conditions.
+
+### Data flow:
+1. The `dns-controller` detects a change to the `dns.operator.openshift.io/default` CR.
+2. The Reconciler calls `ensureDNSConfigMap` → `desiredDNSConfigmap` → `desiredCorefile`.
+3. `desiredCorefile` populates a Go `text/template` with values from the CR's spec.
+4. The rendered Corefile string is placed into the `Data` field of a ConfigMap named `dns-default` in the `openshift-dns` namespace.
+5. The operator creates or updates this ConfigMap via the API.
+6. CoreDNS pods mount this ConfigMap, and the `reload` plugin detects the change, applying it without requiring a pod restart.
+
+## Key Concepts
+- **ManagementState**: OpenShift operators support a `ManagementState` field.
+  - `Managed`: The operator actively reconciles and overwrites manual changes.
+  - `Unmanaged`: The operator pauses reconciliation, allowing manual intervention or debugging.
+  - `Removed`: The operator tears down the managed components.
+- **Idempotency**: All `ensure*` functions (e.g., `ensureDNSDaemonSet`) MUST be idempotent. They must compare the existing state with the desired state and apply changes only if there is a diff.

--- a/.agents/controllers.md
+++ b/.agents/controllers.md
@@ -25,7 +25,7 @@ This CR is the single source of truth for how DNS should behave in the cluster. 
 
 ### Data flow:
 1. The `dns-controller` detects a change to the `dns.operator.openshift.io/default` CR.
-2. The Reconciler calls `ensureDNSConfigMap` → `desiredDNSConfigmap` → `desiredCorefile`.
+2. The Reconciler calls `ensureDNSConfigMap` → `desiredDNSConfigMap` → `desiredCorefile`.
 3. `desiredCorefile` populates a Go `text/template` with values from the CR's spec.
 4. The rendered Corefile string is placed into the `Data` field of a ConfigMap named `dns-default` in the `openshift-dns` namespace.
 5. The operator creates or updates this ConfigMap via the API.

--- a/.agents/controllers.md
+++ b/.agents/controllers.md
@@ -36,4 +36,5 @@ This CR is the single source of truth for how DNS should behave in the cluster. 
   - `Managed`: The operator actively reconciles and overwrites manual changes.
   - `Unmanaged`: The operator pauses reconciliation, allowing manual intervention or debugging.
   - `Removed`: The operator tears down the managed components.
+  - `Force`: The operator aggressively enforces the desired state, even if it might be destructive or bypass some safety checks.
 - **Idempotency**: All `ensure*` functions (e.g., `ensureDNSDaemonSet`) MUST be idempotent. They must compare the existing state with the desired state and apply changes only if there is a diff.

--- a/.agents/operand.md
+++ b/.agents/operand.md
@@ -1,0 +1,23 @@
+# Operand Reference
+
+The `cluster-dns-operator` is the *manager*. The actual DNS service it manages is the **operand**.
+
+## CoreDNS
+- The operand for this operator is **CoreDNS**.
+- The operator does not contain the CoreDNS source code. 
+- The source code for the CoreDNS implementation customized for OpenShift is located in the sibling repository:
+  **`https://github.com/openshift/coredns`**
+- If you need to understand how DNS resolution actually behaves internally (e.g., plugins, caching logic), refer to the codebase in the `https://github.com/openshift/coredns` path. The operator's job is solely to deploy and configure it via the `Corefile` ConfigMap.
+
+## CoreDNS Plugin Chain
+
+The generated Corefile enables a specific set of plugins. OpenShift's default plugin chain includes:
+*   `kubernetes`: Resolves `*.svc.cluster.local` and pod DNS using the Kubernetes API.
+*   `forward`: Forwards external queries to upstream resolvers (defaults to the node's `/etc/resolv.conf`).
+*   `cache`: Caches responses (configurable max TTLs).
+*   `reload`: Hot-reloads the Corefile on ConfigMap changes.
+*   `prometheus`: Exposes metrics at `:9153`.
+*   `health` / `ready`: Health check endpoints for liveness/readiness probes.
+*   `errors`: Error logging.
+*   `bufsize`: Controls EDNS0 buffer size.
+*   `ocp_dnsnameresolver`: Integrates with OVN-Kubernetes for Egress Firewall DNS-based rules, allowing the network policy engine to resolve DNS names for fine-grained egress traffic control.

--- a/.agents/rules.md
+++ b/.agents/rules.md
@@ -1,0 +1,17 @@
+# OpenShift Go Guidelines & CI/CD Caveats
+
+When contributing to this repository, strictly adhere to these OpenShift ecosystem rules.
+
+## Go Coding Guidelines
+- **Idempotency is King**: Reconciliation loops MUST be idempotent. Do not blindly recreate resources; always fetch, compare, and update only if a diff exists.
+- **Never Hardcode**: Do not hardcode namespaces, secrets, or resource names unless defined as strict API constants. Watch namespaces must be configurable.
+- **Structural Schemas**: All Custom Resource Definitions (CRDs) must use OpenAPI v3 validation to strictly validate user input.
+- **Principle of Least Privilege**: The operator must run with minimal RBAC permissions using dedicated ServiceAccounts. Do not add broad permissions.
+
+## CI/CD and Prow Caveats
+OpenShift uses **Prow** for CI/CD automation.
+
+- **Prow Jobs are Auto-Generated**: Do not manually craft Prow job YAMLs. Prow job definitions are generated via `ci-operator-prowgen` from configurations stored centrally in the `openshift/release` repository (`ci-operator/config/openshift/cluster-dns-operator/`).
+- **Changing CI Configs**: If a new e2e test or build step is required, you must submit a PR to the `openshift/release` repository, not this one.
+- **Image Security**: Pipeline configurations implicitly enforce image scanning and signing. Ensure all base images and operands are appropriately tracked.
+- **Local Testing First**: Prow CI runs take time. Always validate changes locally (`make test`) before pushing PRs to trigger Prow jobs.

--- a/.agents/rules.md
+++ b/.agents/rules.md
@@ -4,9 +4,9 @@ When contributing to this repository, strictly adhere to these OpenShift ecosyst
 
 ## Go Coding Guidelines
 - **Idempotency is King**: Reconciliation loops MUST be idempotent. Do not blindly recreate resources; always fetch, compare, and update only if a diff exists.
-- **Never Hardcode**: Do not hardcode namespaces, secrets, or resource names unless defined as strict API constants. Watch namespaces must be configurable.
+- **Never Hardcode (for new/modified code)**: Avoid hardcoding namespaces, secrets, or resource names unless defined as strict API constants. Prefer shared constants and configurable watch namespaces.
 - **Structural Schemas**: All Custom Resource Definitions (CRDs) must use OpenAPI v3 validation to strictly validate user input.
-- **Principle of Least Privilege**: The operator must run with minimal RBAC permissions using dedicated ServiceAccounts. Do not add broad permissions.
+- **Principle of Least Privilege (for new/modified RBAC)**: Use dedicated ServiceAccounts and avoid introducing broader permissions than required. Existing broad permissions should be tracked as technical debt and tightened incrementally.
 
 ## CI/CD and Prow Caveats
 OpenShift uses **Prow** for CI/CD automation.

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -1,0 +1,20 @@
+# Testing Instructions
+
+Rigorous testing is required for all changes in the `cluster-dns-operator`.
+
+## Unit Testing
+- Unit tests are co-located with their respective Go files (e.g., `controller_dns_daemonset_test.go`).
+- Run unit tests locally using standard Go tools or the Makefile:
+  ```bash
+  make test
+  # or
+  go test ./pkg/operator/controller/...
+  ```
+- Focus on testing the generation of desired resources (e.g., ensuring `ensureDNSDaemonSet` produces the exact expected YAML given various cluster state inputs).
+
+## End-to-End (E2E) Testing
+- E2E tests are located in the `test/` directory (e.g., `e2e.test`).
+- These tests expect a live OpenShift cluster.
+- E2E tests are automatically executed by Prow on every Pull Request.
+- **Consistency**: Fit any new tests into existing test libraries and formats rather than introducing new testing frameworks or paradigms.
+- **E2E Necessity**: Read the existing E2E tests to understand the complexity and scope of things currently tested with the suite. Use this context to determine what type of new feature might rise to the level of needing a new E2E test versus a unit test.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Cluster DNS Operator - AI Agent Directory
+
+You are an AI assistant working on the `cluster-dns-operator` repository. This repository is responsible for deploying and managing CoreDNS across OpenShift clusters.
+
+**IMPORTANT:** We use a progressive disclosure architecture for instructions to preserve your context window. Do not attempt to guess architectural patterns or OpenShift conventions.
+
+Depending on the task you are assigned, **read the corresponding file** from the `.agents/` directory before proposing changes:
+
+- **[.agents/context.md](.agents/context.md)**: **ALWAYS READ THIS FIRST** to understand the high-level relationship between the Operator, the CoreDNS Operand, and the OpenShift CNI.
+- **[.agents/architecture.md](.agents/architecture.md)**: Read this if you are making changes to how CoreDNS is deployed, or if you need to understand DNS resolution routing, Node Resolvers, and Key Resources.
+- **[.agents/controllers.md](.agents/controllers.md)**: Read this if you are modifying Go code in `pkg/operator/controller/`, adjusting reconciliation logic, or handling the `dns.operator.openshift.io` API.
+- **[.agents/rules.md](.agents/rules.md)**: Read this to understand strict OpenShift Go coding guidelines, Prow CI/CD caveats, and Operator SDK conventions.
+- **[.agents/testing.md](.agents/testing.md)**: Read this before writing or running unit tests or end-to-end tests.
+- **[.agents/operand.md](.agents/operand.md)**: Read this if you need to understand the CoreDNS operand source code location or its specific plugin chain.


### PR DESCRIPTION
This PR adds a progressive disclosure architecture for AI agents, anchored by `AGENTS.md` and containing deep-dive context in the `.agents/` directory.

See [NE-2391](https://redhat.atlassian.net/browse/NE-2391)

[PR and code changes generated with Gemini LLM and geminii-cli coding agent]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive DNS architecture docs, operator/controller design and reconciliation guidance, operand/CoreDNS behavior and plugin-chain overview, testing instructions, and repository contribution/CI rules.
  * Added agent guidance and context docs with task checklists and repository orientation for contributors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->