### PR TITLE
OCPBUGS-55179: Set internalTrafficPolicy to Local on dns-default service

### DIFF
--- a/pkg/manifests/assets/dns/service.yaml
+++ b/pkg/manifests/assets/dns/service.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 spec:
   # clusterIP will be automatically managed.
   # selector is set at runtime
+  internalTrafficPolicy: Local
   trafficDistribution: PreferSameNode
   ports:
   - name: dns

--- a/pkg/operator/controller/controller_dns_service_test.go
+++ b/pkg/operator/controller/controller_dns_service_test.go
@@ -204,8 +204,7 @@ func TestDesiredDNSServiceInternalTrafficPolicy(t *testing.T) {
 	svc := desiredDNSService(dns, "172.30.0.10", false, daemonsetRef)
 
 	assert.NotNil(t, svc.Spec.InternalTrafficPolicy)
-	assert.Equal(t, corev1.ServiceInternalTrafficPolicyLocal, *svc.Spec.InternalTrafficPolicy,
-		"dns-default service must use InternalTrafficPolicy Local to ensure node-local DNS resolution")
+	assert.Equal(t, corev1.ServiceInternalTrafficPolicyLocal, *svc.Spec.InternalTrafficPolicy)
 }
 
 func Test_shouldEnableTopologyAwareHints(t *testing.T) {

--- a/pkg/operator/controller/controller_dns_service_test.go
+++ b/pkg/operator/controller/controller_dns_service_test.go
@@ -196,6 +196,20 @@ func TestDNSServiceChanged(t *testing.T) {
 	}
 }
 
+func TestDesiredDNSServiceInternalTrafficPolicy(t *testing.T) {
+	dns := &operatorv1.DNS{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+	}
+	daemonsetRef := metav1.OwnerReference{}
+	svc := desiredDNSService(dns, "172.30.0.10", false, daemonsetRef)
+
+	if !assert.NotNil(t, svc.Spec.InternalTrafficPolicy, "expected InternalTrafficPolicy to be set") {
+		return
+	}
+	assert.Equal(t, corev1.ServiceInternalTrafficPolicyLocal, *svc.Spec.InternalTrafficPolicy,
+		"dns-default service must use InternalTrafficPolicy Local to ensure node-local DNS resolution")
+}
+
 func Test_shouldEnableTopologyAwareHints(t *testing.T) {
 	emptyLabels := map[string]string{}
 	someCPU := map[corev1.ResourceName]resource.Quantity{

--- a/pkg/operator/controller/controller_dns_service_test.go
+++ b/pkg/operator/controller/controller_dns_service_test.go
@@ -203,9 +203,7 @@ func TestDesiredDNSServiceInternalTrafficPolicy(t *testing.T) {
 	daemonsetRef := metav1.OwnerReference{}
 	svc := desiredDNSService(dns, "172.30.0.10", false, daemonsetRef)
 
-	if !assert.NotNil(t, svc.Spec.InternalTrafficPolicy, "expected InternalTrafficPolicy to be set") {
-		return
-	}
+	assert.NotNil(t, svc.Spec.InternalTrafficPolicy)
 	assert.Equal(t, corev1.ServiceInternalTrafficPolicyLocal, *svc.Spec.InternalTrafficPolicy,
 		"dns-default service must use InternalTrafficPolicy Local to ensure node-local DNS resolution")
 }


### PR DESCRIPTION
## Summary

DNS queries from pods on primary user-defined networks (UDNs) scatter randomly across dns-default pods on all nodes instead of being handled by the local node's dns-default pod.

UDN pods reach the dns-default service (172.30.0.10) through a path that crosses network boundaries: UDN pod → UDN cluster router → management port → default network → OVN load balancer → dns-default pod. The OVN load balancer on the default network treats dns-default as a standard ClusterIP service and distributes traffic across all backend pods cluster-wide.

Setting `internalTrafficPolicy: Local` restricts the EndpointSlice to contain only the node-local dns-default backend. Since dns-default runs as a DaemonSet with a pod on every node, this is safe and guarantees that DNS queries are always handled by the local pod.

The existing `trafficDistribution: PreferSameNode` (added in PR #457) provides a soft hint for same-node preference but does not guarantee locality for cross-network UDN traffic. `internalTrafficPolicy: Local` provides the hard constraint needed.

## Why DNS operator, not OVN?

The DNS query scatter from primary UDN pods is not caused by an OVN routing bug. In OCP 4.14+ (interconnect mode), each node has its own zone and its own UDN cluster router with a single route — no ECMP happens at the UDN router level. The scatter occurs downstream: once UDN traffic crosses into the default network via the management port, the OVN load balancer distributes dns-default traffic across all backend pods because the service has `internalTrafficPolicy: Cluster` (the default). The fix belongs in the DNS operator, which owns the dns-default service spec.

## Verification

- `make test` — passed
- `make verify` — passed
- On-cluster validation on OCP 4.20 (UPI, 5 nodes) and OCP 4.21 (IPI, 5 nodes):
  - Baseline (ITP=Cluster): DNS queries from UDN pods confirmed scattering across multiple nodes
  - Fix (ITP=Local): OVN LB on each node confirmed to have only the local dns-default pod as backend
  - DNS resolution from UDN pods works correctly with ITP=Local

Jira: https://issues.redhat.com/browse/OCPBUGS-55179

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * DNS service updated to prefer routing pod-to-pod traffic on the local node (internal traffic policy set to Local), reducing cross-node network hops.
* **Tests**
  * Added unit coverage to verify the DNS service internal traffic policy is set to Local.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->