### PR TITLE
WIP [OCPBUGS-82081] Add preStop lifecycle hook to DNS pods to reduce upgrade disruption

### DIFF
--- a/pkg/manifests/assets/dns/daemonset.yaml
+++ b/pkg/manifests/assets/dns/daemonset.yaml
@@ -56,6 +56,10 @@ spec:
             memory: 70Mi
         securityContext:
           readOnlyRootFilesystem: true
+        lifecycle:
+          preStop:
+            exec:
+              command: ["sleep", "5"]
       - name: kube-rbac-proxy
         # image and args are set at runtime by the operator based on the
         # centralized TLS security profile from apiservers.config.openshift.io/cluster
@@ -75,6 +79,7 @@ spec:
           name: tmp-dir
         securityContext:
           readOnlyRootFilesystem: true
+      terminationGracePeriodSeconds: 40
       dnsPolicy: Default
       # nodeSelector is set at runtime.
       volumes:

--- a/pkg/operator/controller/controller_dns_daemonset.go
+++ b/pkg/operator/controller/controller_dns_daemonset.go
@@ -527,6 +527,11 @@ func daemonsetConfigChanged(current, expected *appsv1.DaemonSet) (bool, *appsv1.
 				changed = true
 				break
 			}
+			if !cmp.Equal(a.Lifecycle, b.Lifecycle, cmpopts.EquateEmpty()) {
+				updated.Spec.Template.Spec.Containers = expected.Spec.Template.Spec.Containers
+				changed = true
+				break
+			}
 		}
 	}
 

--- a/pkg/operator/controller/controller_dns_daemonset_test.go
+++ b/pkg/operator/controller/controller_dns_daemonset_test.go
@@ -78,6 +78,11 @@ func TestDesiredDNSDaemonset(t *testing.T) {
 				if e, a := coreDNSImage, c.Image; e != a {
 					t.Errorf("expected daemonset dns image %q, got %q", e, a)
 				}
+				if c.Lifecycle == nil || c.Lifecycle.PreStop == nil {
+					t.Error("expected dns container to have a preStop lifecycle hook")
+				} else if !reflect.DeepEqual(c.Lifecycle.PreStop.Exec.Command, []string{"sleep", "5"}) {
+					t.Errorf("unexpected preStop command: %v", c.Lifecycle.PreStop.Exec.Command)
+				}
 			case "kube-rbac-proxy":
 				if e, a := kubeRBACProxyImage, c.Image; e != a {
 					t.Errorf("expected daemonset kube rbac proxy image %q, got %q", e, a)
@@ -85,6 +90,11 @@ func TestDesiredDNSDaemonset(t *testing.T) {
 			default:
 				t.Errorf("unexpected daemonset container %q", c.Name)
 			}
+		}
+		if ds.Spec.Template.Spec.TerminationGracePeriodSeconds == nil {
+			t.Error("expected terminationGracePeriodSeconds to be set")
+		} else if *ds.Spec.Template.Spec.TerminationGracePeriodSeconds != 40 {
+			t.Errorf("expected terminationGracePeriodSeconds=40, got %d", *ds.Spec.Template.Spec.TerminationGracePeriodSeconds)
 		}
 	}
 }
@@ -423,6 +433,19 @@ func TestDaemonsetConfigChanged(t *testing.T) {
 			description: "if a container args changed",
 			mutate: func(daemonset *appsv1.DaemonSet) {
 				daemonset.Spec.Template.Spec.Containers[1].Args = append(daemonset.Spec.Template.Spec.Containers[1].Args, "--foo")
+			},
+			expect: true,
+		},
+		{
+			description: "if a container lifecycle is added",
+			mutate: func(daemonset *appsv1.DaemonSet) {
+				daemonset.Spec.Template.Spec.Containers[0].Lifecycle = &corev1.Lifecycle{
+					PreStop: &corev1.LifecycleHandler{
+						Exec: &corev1.ExecAction{
+							Command: []string{"sleep", "5"},
+						},
+					},
+				}
 			},
 			expect: true,
 		},


### PR DESCRIPTION
During cluster upgrades, DNS pods are terminated as nodes reboot. There is a race between the kubelet sending SIGTERM to CoreDNS and kube-proxy/OVN removing the pod from the DNS service endpoints. If SIGTERM arrives first, CoreDNS begins its lameduck shutdown while clients are still being routed to the pod, resulting in DNS lookup timeouts.

Add a preStop lifecycle hook with a 5-second sleep to the dns container. This gives the endpoints controller and kube-proxy/OVN time to remove the pod from the ClusterIP service before CoreDNS receives SIGTERM and begins its 20-second lameduck period.

Set terminationGracePeriodSeconds to 40 to accommodate the full shutdown sequence: 5s preStop + 20s CoreDNS lameduck + 15s buffer.

Add Lifecycle to the daemonset change detection so the hook is applied on upgrade without requiring other container field changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved DNS container shutdown behavior with graceful termination handling, including a 5-second pre-shutdown grace period and 40-second pod termination window.

* **Improvements**
  * Enhanced configuration change detection for DNS DaemonSet lifecycle settings, ensuring updates are properly applied and synchronized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->