### PR TITLE
OCPBUGS-86009: Fix dns operator reporting Progressing=True on scale up

### DIFF
--- a/pkg/operator/controller/dns_status.go
+++ b/pkg/operator/controller/dns_status.go
@@ -208,7 +208,9 @@ func computeDNSProgressingCondition(oldCondition *operatorv1.OperatorCondition, 
 		have := dnsDaemonset.Status.UpdatedNumberScheduled // num of nodes running the updated pod.
 		// It's progressing when have < want.  If have >= want, that's okay.
 		if have < want {
-			messages = append(messages, fmt.Sprintf("Have %d up-to-date DNS pods, want %d.", have, want))
+			if isDaemonSetRollingOut(dnsDaemonset) {
+				messages = append(messages, fmt.Sprintf("Have %d up-to-date DNS pods, want %d.", have, want))
+			}
 		}
 
 		haveSelector := dnsDaemonset.Spec.Template.Spec.NodeSelector
@@ -231,7 +233,9 @@ func computeDNSProgressingCondition(oldCondition *operatorv1.OperatorCondition, 
 
 		// It's progressing when have < want.  If have >= want, that's okay.
 		if have < want {
-			messages = append(messages, fmt.Sprintf("Have %d available node-resolver pods, want %d.", have, want))
+			if isDaemonSetRollingOut(nodeResolverDaemonset) {
+				messages = append(messages, fmt.Sprintf("Have %d available node-resolver pods, want %d.", have, want))
+			}
 		}
 	}
 	if len(messages) != 0 {
@@ -349,4 +353,17 @@ func lastTransitionTimeIsRecent(currTime, prevTime time.Time, toleration time.Du
 	default:
 		return elapsed <= toleration
 	}
+}
+
+// isDaemonSetRollingOut determines if the DaemonSet is currently in a rollout state
+// (i.e., actively replacing old pods with new ones or applying a new configuration)
+// versus simply stabilizing (e.g., waiting for pods to start after a node reboot or scale up).
+func isDaemonSetRollingOut(ds *appsv1.DaemonSet) bool {
+	if ds.Generation != ds.Status.ObservedGeneration {
+		return true
+	}
+	if ds.Status.UpdatedNumberScheduled < ds.Status.CurrentNumberScheduled {
+		return true
+	}
+	return false
 }

--- a/pkg/operator/controller/dns_status_test.go
+++ b/pkg/operator/controller/dns_status_test.go
@@ -111,6 +111,7 @@ func TestDNSStatusConditions(t *testing.T) {
 					DesiredNumberScheduled: tc.inputs.desireDNS,
 					NumberAvailable:        tc.inputs.availDNS,
 					UpdatedNumberScheduled: tc.inputs.updatedDNS,
+					CurrentNumberScheduled: tc.inputs.desireDNS,
 				},
 			}
 			dnsDaemonset.Spec.Template.Spec.NodeSelector = nodeSelectorForDNS(&operatorv1.DNS{})
@@ -132,6 +133,7 @@ func TestDNSStatusConditions(t *testing.T) {
 					DesiredNumberScheduled: tc.inputs.desireNR,
 					NumberAvailable:        tc.inputs.availNR,
 					UpdatedNumberScheduled: tc.inputs.updatedNR,
+					CurrentNumberScheduled: tc.inputs.desireNR,
 				},
 			}
 		}
@@ -240,6 +242,7 @@ func TestComputeDNSDegradedCondition(t *testing.T) {
 			Status: appsv1.DaemonSetStatus{
 				DesiredNumberScheduled: int32(desired),
 				NumberAvailable:        int32(available),
+				CurrentNumberScheduled: int32(desired),
 			},
 		}
 	}
@@ -471,6 +474,7 @@ func TestComputeDNSProgressingCondition(t *testing.T) {
 			Status: appsv1.DaemonSetStatus{
 				DesiredNumberScheduled: int32(desired),
 				NumberAvailable:        int32(available),
+				CurrentNumberScheduled: int32(desired),
 				UpdatedNumberScheduled: int32(updated),
 			},
 		}
@@ -638,6 +642,7 @@ func TestSkippingStatusUpdates(t *testing.T) {
 			Status: appsv1.DaemonSetStatus{
 				DesiredNumberScheduled: int32(desired),
 				NumberAvailable:        int32(available),
+				CurrentNumberScheduled: int32(desired),
 				UpdatedNumberScheduled: int32(updated),
 			},
 		}

--- a/pkg/operator/controller/dns_status_test.go
+++ b/pkg/operator/controller/dns_status_test.go
@@ -595,6 +595,32 @@ func TestComputeDNSProgressingCondition(t *testing.T) {
 			tolerations:  customTolerations,
 			expected:     operatorv1.ConditionTrue,
 		},
+		{
+			name:      "DNS daemonset scaling up but not rolling out should not be progressing",
+			clusterIP: "172.30.0.10",
+			dnsDaemonset: func() *appsv1.DaemonSet {
+				ds := makeDaemonSet(6, 5, 5, defaultSelector, defaultTolerations)
+				ds.Status.CurrentNumberScheduled = 5
+				return ds
+			}(),
+			nrDaemonset:  makeDaemonSet(6, 6, 6, defaultSelector, defaultTolerations),
+			nodeSelector: defaultSelector,
+			tolerations:  defaultTolerations,
+			expected:     operatorv1.ConditionFalse,
+		},
+		{
+			name:         "node-resolver daemonset scaling up but not rolling out should not be progressing",
+			clusterIP:    "172.30.0.10",
+			dnsDaemonset: makeDaemonSet(6, 6, 6, defaultSelector, defaultTolerations),
+			nrDaemonset: func() *appsv1.DaemonSet {
+				ds := makeDaemonSet(6, 5, 5, defaultSelector, defaultTolerations)
+				ds.Status.CurrentNumberScheduled = 5
+				return ds
+			}(),
+			nodeSelector: defaultSelector,
+			tolerations:  defaultTolerations,
+			expected:     operatorv1.ConditionFalse,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
The `cluster-dns-operator` was incorrectly reporting `Progressing=True` during normal cluster scale-up events. This was caused by `computeDNSProgressingCondition` checking `UpdatedNumberScheduled` against `DesiredNumberScheduled`. When a new node is added, `DesiredNumberScheduled` increases immediately, but `UpdatedNumberScheduled` lags until the pod is scheduled/running, causing the operator to appear to be rolling out.

This PR introduces an `isDaemonSetRollingOut` helper, modeled after similar logic in the `cluster-ingress-operator` (see [PR #1299](https://github.com/openshift/cluster-ingress-operator/pull/1299)). It checks if the DaemonSet `Generation` matches `ObservedGeneration`, and checks if `UpdatedNumberScheduled` is less than `CurrentNumberScheduled`. If not, the operator is simply scaling and should not report `Progressing=True`.

Tested locally by ensuring the test suite correctly accommodates the new structure and verifies progression states.

Bug: [OCPBUGS-86009](https://redhat.atlassian.net/browse/OCPBUGS-86009)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS component status reporting during DaemonSet updates. “Have…want…” progressing messages are now shown only when the DNS and node-resolver DaemonSets are actively rolling out, and are suppressed when counts don’t match but a rollout isn’t in progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->