### PR TITLE
status: sort isUpgrading messages to prevent ClusterOperator write loop

### DIFF
--- a/pkg/operator/controller/status/controller.go
+++ b/pkg/operator/controller/status/controller.go
@@ -3,6 +3,7 @@ package status
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/google/go-cmp/cmp"
@@ -532,6 +533,7 @@ func isUpgrading(curVersions, oldVersions, newVersions map[string]string) (bool,
 			messages = append(messages, fmt.Sprintf("Upgrading %s to %q.", name, newVersion))
 		}
 	}
+	sort.Strings(messages)
 	return upgrading, messages
 }
 

--- a/pkg/operator/controller/status/controller_test.go
+++ b/pkg/operator/controller/status/controller_test.go
@@ -811,9 +811,6 @@ func TestComputeOperatorDegradedCondition(t *testing.T) {
 // false, the ClusterOperator was written, the CO watch fired, and the cycle
 // repeated indefinitely during upgrades.
 func TestIsUpgradingMessageOrder(t *testing.T) {
-	// Two components upgrading simultaneously — map iteration order is random,
-	// so call isUpgrading many times and confirm the messages slice is always
-	// returned in the same sorted order.
 	curVersions := map[string]string{
 		OperatorVersionName: "v1",
 		CoreDNSVersionName:  "dns-v1",
@@ -830,18 +827,27 @@ func TestIsUpgradingMessageOrder(t *testing.T) {
 		KubeRBACProxyName:   "rbac-v2",
 	}
 
-	var first []string
+	// expectedMessages is the lexicographically sorted set of messages
+	// isUpgrading must produce for the above inputs. "Upgraded" sorts before
+	// "Upgrading" (byte 8: 'd' < 'i'), and within each prefix components are
+	// ordered alphabetically: coredns < kube-rbac-proxy < operator.
+	expectedMessages := []string{
+		`Upgraded coredns to "dns-v1".`,
+		`Upgraded kube-rbac-proxy to "rbac-v1".`,
+		`Upgraded operator to "v1".`,
+		`Upgrading coredns to "dns-v2".`,
+		`Upgrading kube-rbac-proxy to "rbac-v2".`,
+		`Upgrading operator to "v2".`,
+	}
+
+	// Call isUpgrading many times to exercise Go's randomized map iteration.
 	for i := 0; i < 100; i++ {
 		upgrading, messages := isUpgrading(curVersions, oldVersions, newVersions)
 		if !upgrading {
 			t.Fatal("expected upgrading=true")
 		}
-		if i == 0 {
-			first = messages
-			continue
-		}
-		if !reflect.DeepEqual(first, messages) {
-			t.Errorf("iteration %d: messages order changed\n  first:   %v\n  current: %v", i, first, messages)
+		if !reflect.DeepEqual(messages, expectedMessages) {
+			t.Errorf("iteration %d: unexpected messages\n  want: %v\n  got:  %v", i, expectedMessages, messages)
 		}
 	}
 }

--- a/pkg/operator/controller/status/controller_test.go
+++ b/pkg/operator/controller/status/controller_test.go
@@ -1,6 +1,7 @@
 package status
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
@@ -799,6 +800,48 @@ func TestComputeOperatorDegradedCondition(t *testing.T) {
 		}
 		if !cmp.Equal(actual, expected, conditionsCmpOpts...) {
 			t.Errorf("%q: expected %#v, got %#v", tc.description, expected, actual)
+		}
+	}
+}
+
+// TestIsUpgradingMessageOrder verifies that isUpgrading returns messages in a
+// stable, sorted order regardless of map iteration order. Non-deterministic
+// message ordering caused a self-sustaining ClusterOperator write loop: each
+// reconcile produced a different Message string, operatorStatusesEqual returned
+// false, the ClusterOperator was written, the CO watch fired, and the cycle
+// repeated indefinitely during upgrades.
+func TestIsUpgradingMessageOrder(t *testing.T) {
+	// Two components upgrading simultaneously — map iteration order is random,
+	// so call isUpgrading many times and confirm the messages slice is always
+	// returned in the same sorted order.
+	curVersions := map[string]string{
+		OperatorVersionName: "v1",
+		CoreDNSVersionName:  "dns-v1",
+		KubeRBACProxyName:   "rbac-v1",
+	}
+	oldVersions := map[string]string{
+		OperatorVersionName: "v0",
+		CoreDNSVersionName:  "dns-v0",
+		KubeRBACProxyName:   "rbac-v0",
+	}
+	newVersions := map[string]string{
+		OperatorVersionName: "v2",
+		CoreDNSVersionName:  "dns-v2",
+		KubeRBACProxyName:   "rbac-v2",
+	}
+
+	var first []string
+	for i := 0; i < 100; i++ {
+		upgrading, messages := isUpgrading(curVersions, oldVersions, newVersions)
+		if !upgrading {
+			t.Fatal("expected upgrading=true")
+		}
+		if i == 0 {
+			first = messages
+			continue
+		}
+		if !reflect.DeepEqual(first, messages) {
+			t.Errorf("iteration %d: messages order changed\n  first:   %v\n  current: %v", i, first, messages)
 		}
 	}
 }


### PR DESCRIPTION
## Problem

During a cluster upgrade, `oc get co -w` shows the `dns` ClusterOperator being updated many times per second, even when the pod counts in the Progressing message haven't changed.

## Root Cause

`isUpgrading()` iterates over a `map[string]string` to build upgrade status messages. Go map iteration order is randomized, so when multiple operands are upgrading simultaneously (e.g. `coredns` and `kube-rbac-proxy`), the returned `messages` slice has a non-deterministic order on each call.

This caused a self-sustaining write loop:

1. `isUpgrading()` produces messages in order `[A, B]`
2. `operatorStatusesEqual()` returns false (Message differs from stored)
3. ClusterOperator is written
4. The CO watch fires, triggering another reconcile
5. `isUpgrading()` produces messages in order `[B, A]`
6. `operatorStatusesEqual()` returns false again
7. ClusterOperator is written again → goto 4

## Fix

Sort the `messages` slice before returning from `isUpgrading()`, making the output deterministic and breaking the loop.

## Testing

Added a unit test that calls `isUpgrading()` 100 times with multiple upgrading components and asserts the messages are always returned in the same sorted order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made upgrade status messages consistently ordered across reconciliations.
  * Improved the stability of upgrade progress updates so message order no longer varies.
* **Tests**
  * Added a regression test to verify upgrade status message ordering stays deterministic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->