### PR TITLE
NE-2817: Gate operator metrics TLS on tlsAdherence via ShouldHonorClusterTLSProfile

### DIFF
--- a/cmd/dns-operator/main.go
+++ b/cmd/dns-operator/main.go
@@ -5,8 +5,8 @@ import (
 	"crypto/tls"
 	"flag"
 	"os"
+	"time"
 
-	configv1 "github.com/openshift/api/config/v1"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	operatorcontroller "github.com/openshift/cluster-dns-operator/pkg/operator/controller"
 
@@ -17,6 +17,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -61,35 +62,65 @@ func main() {
 		logrus.Fatalf("failed to get kube config: %v", err)
 	}
 
-	// Build TLS options for the operator metrics server from the
-	// cluster-wide TLS security profile when secure serving is enabled.
+	// Build TLS options for the operator metrics server, gated on the
+	// cluster's tlsAdherence policy.  Under LegacyAdheringComponentsOnly
+	// (the default) no cluster TLS profile is applied because operator
+	// metrics is a newly adhering surface.  Under StrictAllComponents the
+	// cluster TLS profile is applied.
 	// NOTE: the TLS profile is read once at startup; runtime changes to
-	// APIServer.spec.tlsSecurityProfile require an operator restart.
+	// APIServer require an operator restart.
 	var metricsTLSOpts []func(*tls.Config)
 	if *metricsCertDir != "" {
 		cfgClient, err := configclient.NewForConfig(kubeConfig)
 		if err != nil {
 			logrus.Fatalf("failed to create config client: %v", err)
 		}
-		apiServer, err := cfgClient.ConfigV1().APIServers().Get(context.TODO(), "cluster", metav1.GetOptions{})
-		var tlsSecurityProfile *configv1.TLSSecurityProfile
-		if err != nil {
-			logrus.Warningf("failed to get apiserver config, using Intermediate TLS profile: %v", err)
-		} else {
-			tlsSecurityProfile = apiServer.Spec.TLSSecurityProfile
+		// Retry fetching the APIServer config with exponential backoff
+		// (2s, 4s, 8s) because the API server may be temporarily
+		// unreachable during cluster bootstrap or upgrades.
+		backoff := wait.Backoff{
+			Duration: 2 * time.Second,
+			Factor:   2,
+			Steps:    3,
 		}
-		profileSpec := operatorcontroller.TLSProfileSpecForSecurityProfile(tlsSecurityProfile)
-		tlsCfg, err := operatorcontroller.TLSConfigFromProfile(profileSpec)
-		if err != nil {
-			logrus.Fatalf("failed to build TLS config from profile: %v", err)
-		}
-		metricsTLSOpts = append(metricsTLSOpts, func(cfg *tls.Config) {
-			cfg.CipherSuites = tlsCfg.CipherSuites
-			cfg.MinVersion = tlsCfg.MinVersion
-			if len(tlsCfg.CurvePreferences) > 0 {
-				cfg.CurvePreferences = tlsCfg.CurvePreferences
+		var lastErr error
+		err = wait.ExponentialBackoff(backoff, func() (bool, error) {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			apiServer, getErr := cfgClient.ConfigV1().APIServers().Get(ctx, "cluster", metav1.GetOptions{})
+			if getErr != nil {
+				logrus.Warningf("failed to get apiserver config (will retry): %v", getErr)
+				lastErr = getErr
+				return false, nil
 			}
+			metricsTLSOpts, lastErr = operatorcontroller.MetricsTLSOptsFromAPIServer(apiServer)
+			if lastErr != nil {
+				return false, lastErr
+			}
+			return true, nil
 		})
+		// If all retries were exhausted, fall back to the Intermediate
+		// TLS profile so the operator can still start with secure defaults.
+		// A non-transient error from MetricsTLSOptsFromAPIServer is fatal.
+		if err != nil {
+			if wait.Interrupted(err) {
+				logrus.Warningf("failed to get apiserver config after retries, falling back to Intermediate TLS profile for operator metrics: %v", lastErr)
+			} else {
+				logrus.Fatalf("failed to build TLS options from apiserver config: %v", err)
+			}
+			profileSpec := operatorcontroller.TLSProfileSpecForSecurityProfile(nil)
+			tlsCfg, tlsErr := operatorcontroller.TLSConfigFromProfile(profileSpec)
+			if tlsErr != nil {
+				logrus.Fatalf("failed to build TLS config from Intermediate profile: %v", tlsErr)
+			}
+			metricsTLSOpts = append(metricsTLSOpts, func(cfg *tls.Config) {
+				cfg.CipherSuites = tlsCfg.CipherSuites
+				cfg.MinVersion = tlsCfg.MinVersion
+				if len(tlsCfg.CurvePreferences) > 0 {
+					cfg.CurvePreferences = tlsCfg.CurvePreferences
+				}
+			})
+		}
 	}
 
 	operatorConfig := operatorconfig.Config{

--- a/pkg/operator/controller/tls.go
+++ b/pkg/operator/controller/tls.go
@@ -75,6 +75,48 @@ func TLSConfigFromProfile(spec *configv1.TLSProfileSpec) (*tls.Config, error) {
 	return crypto.SecureTLSConfig(cfg), nil
 }
 
+// MetricsTLSOptsFromAPIServer returns TLS configuration mutators for the
+// operator metrics server, gated on the cluster's tlsAdherence policy.
+// When ShouldHonorClusterTLSProfile returns false (Legacy/NoOpinion), no
+// mutators are returned and the caller should use default TLS settings.
+func MetricsTLSOptsFromAPIServer(apiServer *configv1.APIServer) ([]func(*tls.Config), error) {
+	if apiServer == nil {
+		return nil, nil
+	}
+
+	adherence := apiServer.Spec.TLSAdherence
+
+	switch adherence {
+	case configv1.TLSAdherencePolicyNoOpinion,
+		configv1.TLSAdherencePolicyLegacyAdheringComponentsOnly,
+		configv1.TLSAdherencePolicyStrictAllComponents:
+	default:
+		logrus.Warningf("MetricsTLSOptsFromAPIServer: unrecognized tlsAdherence value %q, defaulting to Strict behavior (honoring cluster TLS profile)", adherence)
+	}
+
+	if !crypto.ShouldHonorClusterTLSProfile(adherence) {
+		logrus.Infof("MetricsTLSOptsFromAPIServer: tlsAdherence=%q, not applying cluster TLS profile to operator metrics", adherence)
+		return nil, nil
+	}
+
+	logrus.Infof("MetricsTLSOptsFromAPIServer: tlsAdherence=%q, applying cluster TLS security profile to operator metrics", adherence)
+
+	profileSpec := TLSProfileSpecForSecurityProfile(apiServer.Spec.TLSSecurityProfile)
+	tlsCfg, err := TLSConfigFromProfile(profileSpec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build TLS config from cluster profile: %w", err)
+	}
+
+	mutator := func(cfg *tls.Config) {
+		cfg.CipherSuites = tlsCfg.CipherSuites
+		cfg.MinVersion = tlsCfg.MinVersion
+		if len(tlsCfg.CurvePreferences) > 0 {
+			cfg.CurvePreferences = tlsCfg.CurvePreferences
+		}
+	}
+	return []func(*tls.Config){mutator}, nil
+}
+
 // TLSProfileSpecForSecurityProfile returns a TLSProfileSpec based on the
 // provided security profile, or the Intermediate profile if an unknown
 // profile type is provided or the profile is nil.

--- a/pkg/operator/controller/tls_test.go
+++ b/pkg/operator/controller/tls_test.go
@@ -140,6 +140,164 @@ func TestTLSConfigFromProfile(t *testing.T) {
 	})
 }
 
+func TestMetricsTLSOptsFromAPIServer(t *testing.T) {
+	tests := []struct {
+		name            string
+		apiServer       *configv1.APIServer
+		wantNil         bool
+		wantErr         bool
+		expectedProfile *configv1.TLSProfileSpec
+	}{
+		{
+			name:      "nil APIServer returns nil",
+			apiServer: nil,
+			wantNil:   true,
+		},
+		{
+			name: "NoOpinion (empty string) returns nil",
+			apiServer: &configv1.APIServer{
+				Spec: configv1.APIServerSpec{
+					TLSAdherence: configv1.TLSAdherencePolicyNoOpinion,
+				},
+			},
+			wantNil: true,
+		},
+		{
+			name: "LegacyAdheringComponentsOnly returns nil",
+			apiServer: &configv1.APIServer{
+				Spec: configv1.APIServerSpec{
+					TLSAdherence: configv1.TLSAdherencePolicyLegacyAdheringComponentsOnly,
+				},
+			},
+			wantNil: true,
+		},
+		{
+			name: "StrictAllComponents returns TLS mutators",
+			apiServer: &configv1.APIServer{
+				Spec: configv1.APIServerSpec{
+					TLSAdherence: configv1.TLSAdherencePolicyStrictAllComponents,
+				},
+			},
+			wantNil: false,
+		},
+		{
+			name: "unknown value returns TLS mutators (defaults to Strict)",
+			apiServer: &configv1.APIServer{
+				Spec: configv1.APIServerSpec{
+					TLSAdherence: "FuturePolicy",
+					TLSSecurityProfile: &configv1.TLSSecurityProfile{
+						Type: configv1.TLSProfileOldType,
+					},
+				},
+			},
+			wantNil:         false,
+			expectedProfile: configv1.TLSProfiles[configv1.TLSProfileOldType],
+		},
+		{
+			name: "StrictAllComponents with nil TLSSecurityProfile uses Intermediate defaults",
+			apiServer: &configv1.APIServer{
+				Spec: configv1.APIServerSpec{
+					TLSAdherence:       configv1.TLSAdherencePolicyStrictAllComponents,
+					TLSSecurityProfile: nil,
+				},
+			},
+			wantNil:         false,
+			expectedProfile: configv1.TLSProfiles[configv1.TLSProfileIntermediateType],
+		},
+		{
+			name: "StrictAllComponents with explicit profile applies it",
+			apiServer: &configv1.APIServer{
+				Spec: configv1.APIServerSpec{
+					TLSAdherence: configv1.TLSAdherencePolicyStrictAllComponents,
+					TLSSecurityProfile: &configv1.TLSSecurityProfile{
+						Type: configv1.TLSProfileOldType,
+					},
+				},
+			},
+			wantNil:         false,
+			expectedProfile: configv1.TLSProfiles[configv1.TLSProfileOldType],
+		},
+		{
+			name: "StrictAllComponents with Custom profile including Groups",
+			apiServer: &configv1.APIServer{
+				Spec: configv1.APIServerSpec{
+					TLSAdherence: configv1.TLSAdherencePolicyStrictAllComponents,
+					TLSSecurityProfile: &configv1.TLSSecurityProfile{
+						Type: configv1.TLSProfileCustomType,
+						Custom: &configv1.CustomTLSProfile{
+							TLSProfileSpec: configv1.TLSProfileSpec{
+								Ciphers:       []string{"ECDHE-RSA-AES256-GCM-SHA384"},
+								MinTLSVersion: configv1.VersionTLS12,
+								Groups: []configv1.TLSGroup{
+									configv1.TLSGroupX25519,
+									configv1.TLSGroupSecP256r1,
+								},
+							},
+						},
+					},
+				},
+			},
+			wantNil: false,
+			expectedProfile: &configv1.TLSProfileSpec{
+				Ciphers:       []string{"ECDHE-RSA-AES256-GCM-SHA384"},
+				MinTLSVersion: configv1.VersionTLS12,
+				Groups: []configv1.TLSGroup{
+					configv1.TLSGroupX25519,
+					configv1.TLSGroupSecP256r1,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts, err := MetricsTLSOptsFromAPIServer(tt.apiServer)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("MetricsTLSOptsFromAPIServer() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantNil && opts != nil {
+				t.Errorf("expected nil opts, got %v", opts)
+			}
+			if !tt.wantNil && opts == nil {
+				t.Error("expected non-nil opts, got nil")
+			}
+			if !tt.wantNil && opts != nil {
+				cfg := &tls.Config{}
+				opts[0](cfg)
+				if cfg.MinVersion == 0 {
+					t.Error("expected MinVersion to be set by mutator")
+				}
+				if tt.expectedProfile != nil {
+					expectedCfg, err := TLSConfigFromProfile(tt.expectedProfile)
+					if err != nil {
+						t.Fatalf("failed to build expected config: %v", err)
+					}
+					if cfg.MinVersion != expectedCfg.MinVersion {
+						t.Errorf("MinVersion: got %d, want %d", cfg.MinVersion, expectedCfg.MinVersion)
+					}
+					if len(cfg.CipherSuites) != len(expectedCfg.CipherSuites) {
+						t.Errorf("CipherSuites count: got %d, want %d", len(cfg.CipherSuites), len(expectedCfg.CipherSuites))
+					} else {
+						for i := range expectedCfg.CipherSuites {
+							if cfg.CipherSuites[i] != expectedCfg.CipherSuites[i] {
+								t.Errorf("CipherSuites[%d]: got %d, want %d", i, cfg.CipherSuites[i], expectedCfg.CipherSuites[i])
+							}
+						}
+					}
+					if len(cfg.CurvePreferences) != len(expectedCfg.CurvePreferences) {
+						t.Errorf("CurvePreferences count: got %d, want %d", len(cfg.CurvePreferences), len(expectedCfg.CurvePreferences))
+					} else {
+						for i := range expectedCfg.CurvePreferences {
+							if cfg.CurvePreferences[i] != expectedCfg.CurvePreferences[i] {
+								t.Errorf("CurvePreferences[%d]: got %v, want %v", i, cfg.CurvePreferences[i], expectedCfg.CurvePreferences[i])
+							}
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestTLSProfileSpecForSecurityProfile(t *testing.T) {
 	t.Run("nil profile defaults to Intermediate", func(t *testing.T) {
 		spec := TLSProfileSpecForSecurityProfile(nil)


### PR DESCRIPTION
## Summary

- Add `MetricsTLSOptsFromAPIServer()` helper in `pkg/operator/controller/tls.go` that gates operator metrics TLS profile application on the cluster's `tlsAdherence` policy via library-go's `crypto.ShouldHonorClusterTLSProfile()`
- Under `LegacyAdheringComponentsOnly` (default) or `NoOpinion`: no cluster TLS profile is applied to operator metrics (newly adhering surface)
- Under `StrictAllComponents` or unrecognized values: cluster TLS security profile is applied
- Unrecognized enum values log a warning and default to Strict (forward-compat)
- APIServer Get failure falls back to the Intermediate TLS profile (preserving [NE-2743](https://redhat.atlassian.net/browse/NE-2743) central TLS behaviour) and logs a warning
- Unit tests cover nil, NoOpinion, Legacy, Strict, unknown, and profile application scenarios

## Test plan

- [x] `make build` passes
- [x] `make test` passes (30 TLS-related tests, all green)
- [x] `make verify` passes (gofmt, CRDs, deps)
- [ ] E2E: verify operator starts with default `LegacyAdheringComponentsOnly` and does NOT apply cluster TLS profile to metrics
- [ ] E2E: verify operator applies cluster TLS profile to metrics when `StrictAllComponents` is set
- [ ] E2E: verify operator falls back to Intermediate TLS profile when APIServer config is unavailable

🤖 Generated with [Claude Code](https://claude.ai/claude-code) via `/jira:solve [NE-2817](https://redhat.atlassian.net/browse/NE-2817)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Operator metrics TLS settings now follow the cluster TLS adherence policy.
  - Strict adherence applies the cluster TLS security profile to operator metrics; legacy adherence keeps prior behavior.
- **Bug Fixes**
  - If the API server TLS configuration can’t be determined, operator metrics TLS falls back to secure intermediate defaults and logs a warning.
  - Unknown TLS adherence values default to strict behavior.
- **Tests**
  - Added unit tests covering metrics TLS option derivation across adherence and TLS profile combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->