### PR TITLE
WIP: Bump Go toolchain to 1.26 and pin protobuf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-4.22 AS builder
 WORKDIR /dns-operator
 COPY . .
 RUN make build

--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,7 @@ require (
 	golang.org/x/time v0.9.0 // indirect
 	golang.org/x/tools v0.38.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
-	google.golang.org/protobuf v1.36.8 // indirect
+	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -197,8 +197,8 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.4.0 h1:Ci3iUJyx9UeRx7CeFN8ARgGbkESwJK+KB9lLcWxY/Zw=
 gomodules.xyz/jsonpatch/v2 v2.4.0/go.mod h1:AH3dM2RI6uoBZxn3LVrfvJ3E0/9dG4cSrbuBJT4moAY=
-google.golang.org/protobuf v1.36.8 h1:xHScyCOEuuwZEc6UtSOvPbAT4zRh0xcNRYekJwfqyMc=
-google.golang.org/protobuf v1.36.8/go.mod h1:fuxRtAxBytpl4zzqUh6/eyUujkJdNiuEkXntxiD/uRU=
+google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af h1:+5/Sw3GsDNlEmu7TfklWKPdQ0Ykja5VEmq2i817+jbI=
+google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/vendor/google.golang.org/protobuf/internal/descfmt/stringer.go
+++ b/vendor/google.golang.org/protobuf/internal/descfmt/stringer.go
@@ -83,12 +83,13 @@ func formatListOpt(vs list, isRoot, allowMulti bool) string {
 	case protoreflect.FileImports:
 		for i := 0; i < vs.Len(); i++ {
 			var rs records
-			rv := reflect.ValueOf(vs.Get(i))
-			rs.Append(rv, []methodAndName{
-				{rv.MethodByName("Path"), "Path"},
-				{rv.MethodByName("Package"), "Package"},
-				{rv.MethodByName("IsPublic"), "IsPublic"},
-				{rv.MethodByName("IsWeak"), "IsWeak"},
+			fi := vs.Get(i)
+			rv := reflect.ValueOf(fi)
+			rs.Append(rv, []attrAndName{
+				{fi.Path(), "Path"},
+				{fi.Package(), "Package"},
+				{fi.IsPublic, "IsPublic"},
+				{fi.IsWeak, "IsWeak"},
 			}...)
 			ss = append(ss, "{"+rs.Join()+"}")
 		}
@@ -104,9 +105,9 @@ func formatListOpt(vs list, isRoot, allowMulti bool) string {
 	}
 }
 
-type methodAndName struct {
-	method reflect.Value
-	name   string
+type attrAndName struct {
+	attr any
+	name string
 }
 
 func FormatDesc(s fmt.State, r rune, t protoreflect.Descriptor) {
@@ -126,58 +127,58 @@ func formatDescOpt(t protoreflect.Descriptor, isRoot, allowMulti bool, record fu
 		start = rt.Name() + "{"
 	}
 
-	_, isFile := t.(protoreflect.FileDescriptor)
+	fd, isFile := t.(protoreflect.FileDescriptor)
 	rs := records{
 		allowMulti: allowMulti,
 		record:     record,
 	}
 	if t.IsPlaceholder() {
 		if isFile {
-			rs.Append(rv, []methodAndName{
-				{rv.MethodByName("Path"), "Path"},
-				{rv.MethodByName("Package"), "Package"},
-				{rv.MethodByName("IsPlaceholder"), "IsPlaceholder"},
+			rs.Append(rv, []attrAndName{
+				{fd.Path(), "Path"},
+				{fd.Package(), "Package"},
+				{fd.IsPlaceholder(), "IsPlaceholder"},
 			}...)
 		} else {
-			rs.Append(rv, []methodAndName{
-				{rv.MethodByName("FullName"), "FullName"},
-				{rv.MethodByName("IsPlaceholder"), "IsPlaceholder"},
+			rs.Append(rv, []attrAndName{
+				{t.FullName(), "FullName"},
+				{t.IsPlaceholder(), "IsPlaceholder"},
 			}...)
 		}
 	} else {
 		switch {
 		case isFile:
-			rs.Append(rv, methodAndName{rv.MethodByName("Syntax"), "Syntax"})
+			rs.Append(rv, attrAndName{fd.Syntax(), "Syntax"})
 		case isRoot:
-			rs.Append(rv, []methodAndName{
-				{rv.MethodByName("Syntax"), "Syntax"},
-				{rv.MethodByName("FullName"), "FullName"},
+			rs.Append(rv, []attrAndName{
+				{t.Syntax(), "Syntax"},
+				{t.FullName(), "FullName"},
 			}...)
 		default:
-			rs.Append(rv, methodAndName{rv.MethodByName("Name"), "Name"})
+			rs.Append(rv, attrAndName{t.Name(), "Name"})
 		}
 		switch t := t.(type) {
 		case protoreflect.FieldDescriptor:
-			accessors := []methodAndName{
-				{rv.MethodByName("Number"), "Number"},
-				{rv.MethodByName("Cardinality"), "Cardinality"},
-				{rv.MethodByName("Kind"), "Kind"},
-				{rv.MethodByName("HasJSONName"), "HasJSONName"},
-				{rv.MethodByName("JSONName"), "JSONName"},
-				{rv.MethodByName("HasPresence"), "HasPresence"},
-				{rv.MethodByName("IsExtension"), "IsExtension"},
-				{rv.MethodByName("IsPacked"), "IsPacked"},
-				{rv.MethodByName("IsWeak"), "IsWeak"},
-				{rv.MethodByName("IsList"), "IsList"},
-				{rv.MethodByName("IsMap"), "IsMap"},
-				{rv.MethodByName("MapKey"), "MapKey"},
-				{rv.MethodByName("MapValue"), "MapValue"},
-				{rv.MethodByName("HasDefault"), "HasDefault"},
-				{rv.MethodByName("Default"), "Default"},
-				{rv.MethodByName("ContainingOneof"), "ContainingOneof"},
-				{rv.MethodByName("ContainingMessage"), "ContainingMessage"},
-				{rv.MethodByName("Message"), "Message"},
-				{rv.MethodByName("Enum"), "Enum"},
+			accessors := []attrAndName{
+				{t.Number(), "Number"},
+				{t.Cardinality(), "Cardinality"},
+				{t.Kind(), "Kind"},
+				{t.HasJSONName(), "HasJSONName"},
+				{t.JSONName(), "JSONName"},
+				{t.HasPresence(), "HasPresence"},
+				{t.IsExtension(), "IsExtension"},
+				{t.IsPacked(), "IsPacked"},
+				{t.IsWeak(), "IsWeak"},
+				{t.IsList(), "IsList"},
+				{t.IsMap(), "IsMap"},
+				{t.MapKey(), "MapKey"},
+				{t.MapValue(), "MapValue"},
+				{t.HasDefault(), "HasDefault"},
+				{t.Default(), "Default"},
+				{t.ContainingOneof(), "ContainingOneof"},
+				{t.ContainingMessage(), "ContainingMessage"},
+				{t.Message(), "Message"},
+				{t.Enum(), "Enum"},
 			}
 			for _, s := range accessors {
 				switch s.name {
@@ -223,58 +224,54 @@ func formatDescOpt(t protoreflect.Descriptor, isRoot, allowMulti bool, record fu
 			}
 
 		case protoreflect.FileDescriptor:
-			rs.Append(rv, []methodAndName{
-				{rv.MethodByName("Path"), "Path"},
-				{rv.MethodByName("Package"), "Package"},
-				{rv.MethodByName("Imports"), "Imports"},
-				{rv.MethodByName("Messages"), "Messages"},
-				{rv.MethodByName("Enums"), "Enums"},
-				{rv.MethodByName("Extensions"), "Extensions"},
-				{rv.MethodByName("Services"), "Services"},
+			rs.Append(rv, []attrAndName{
+				{t.Path(), "Path"},
+				{t.Package(), "Package"},
+				{t.Imports(), "Imports"},
+				{t.Messages(), "Messages"},
+				{t.Enums(), "Enums"},
+				{t.Extensions(), "Extensions"},
+				{t.Services(), "Services"},
 			}...)
 
 		case protoreflect.MessageDescriptor:
-			rs.Append(rv, []methodAndName{
-				{rv.MethodByName("IsMapEntry"), "IsMapEntry"},
-				{rv.MethodByName("Fields"), "Fields"},
-				{rv.MethodByName("Oneofs"), "Oneofs"},
-				{rv.MethodByName("ReservedNames"), "ReservedNames"},
-				{rv.MethodByName("ReservedRanges"), "ReservedRanges"},
-				{rv.MethodByName("RequiredNumbers"), "RequiredNumbers"},
-				{rv.MethodByName("ExtensionRanges"), "ExtensionRanges"},
-				{rv.MethodByName("Messages"), "Messages"},
-				{rv.MethodByName("Enums"), "Enums"},
-				{rv.MethodByName("Extensions"), "Extensions"},
+			rs.Append(rv, []attrAndName{
+				{t.IsMapEntry(), "IsMapEntry"},
+				{t.Fields(), "Fields"},
+				{t.Oneofs(), "Oneofs"},
+				{t.ReservedNames(), "ReservedNames"},
+				{t.ReservedRanges(), "ReservedRanges"},
+				{t.RequiredNumbers(), "RequiredNumbers"},
+				{t.ExtensionRanges(), "ExtensionRanges"},
+				{t.Messages(), "Messages"},
+				{t.Enums(), "Enums"},
+				{t.Extensions(), "Extensions"},
 			}...)
 
 		case protoreflect.EnumDescriptor:
-			rs.Append(rv, []methodAndName{
-				{rv.MethodByName("Values"), "Values"},
-				{rv.MethodByName("ReservedNames"), "ReservedNames"},
-				{rv.MethodByName("ReservedRanges"), "ReservedRanges"},
-				{rv.MethodByName("IsClosed"), "IsClosed"},
+			rs.Append(rv, []attrAndName{
+				{t.Values(), "Values"},
+				{t.ReservedNames(), "ReservedNames"},
+				{t.ReservedRanges(), "ReservedRanges"},
+				{t.IsClosed(), "IsClosed"},
 			}...)
 
 		case protoreflect.EnumValueDescriptor:
-			rs.Append(rv, []methodAndName{
-				{rv.MethodByName("Number"), "Number"},
-			}...)
+			rs.Append(rv, attrAndName{t.Number(), "Number"})
 
 		case protoreflect.ServiceDescriptor:
-			rs.Append(rv, []methodAndName{
-				{rv.MethodByName("Methods"), "Methods"},
-			}...)
+			rs.Append(rv, attrAndName{t.Methods(), "Methods"})
 
 		case protoreflect.MethodDescriptor:
-			rs.Append(rv, []methodAndName{
-				{rv.MethodByName("Input"), "Input"},
-				{rv.MethodByName("Output"), "Output"},
-				{rv.MethodByName("IsStreamingClient"), "IsStreamingClient"},
-				{rv.MethodByName("IsStreamingServer"), "IsStreamingServer"},
+			rs.Append(rv, []attrAndName{
+				{t.Input(), "Input"},
+				{t.Output(), "Output"},
+				{t.IsStreamingClient(), "IsStreamingClient"},
+				{t.IsStreamingServer(), "IsStreamingServer"},
 			}...)
 		}
-		if m := rv.MethodByName("GoType"); m.IsValid() {
-			rs.Append(rv, methodAndName{m, "GoType"})
+		if m, ok := t.(interface{ GoType() reflect.Type }); ok {
+			rs.Append(rv, attrAndName{m.GoType(), "GoType"})
 		}
 	}
 	return start + rs.Join() + end
@@ -297,68 +294,66 @@ func (rs *records) AppendRecs(fieldName string, newRecs [2]string) {
 	rs.recs = append(rs.recs, newRecs)
 }
 
-func (rs *records) Append(v reflect.Value, accessors ...methodAndName) {
-	for _, a := range accessors {
-		if rs.record != nil {
-			rs.record(a.name)
-		}
-		var rv reflect.Value
-		if a.method.IsValid() {
-			rv = a.method.Call(nil)[0]
-		}
-		if v.Kind() == reflect.Struct && !rv.IsValid() {
-			rv = v.FieldByName(a.name)
-		}
-		if !rv.IsValid() {
-			panic(fmt.Sprintf("unknown accessor: %v.%s", v.Type(), a.name))
-		}
-		if _, ok := rv.Interface().(protoreflect.Value); ok {
-			rv = rv.MethodByName("Interface").Call(nil)[0]
-			if !rv.IsNil() {
-				rv = rv.Elem()
-			}
-		}
-
-		// Ignore zero values.
-		var isZero bool
-		switch rv.Kind() {
-		case reflect.Interface, reflect.Slice:
-			isZero = rv.IsNil()
-		case reflect.Bool:
-			isZero = rv.Bool() == false
-		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-			isZero = rv.Int() == 0
-		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-			isZero = rv.Uint() == 0
-		case reflect.String:
-			isZero = rv.String() == ""
-		}
-		if n, ok := rv.Interface().(list); ok {
-			isZero = n.Len() == 0
-		}
-		if isZero {
-			continue
-		}
-
-		// Format the value.
-		var s string
-		v := rv.Interface()
-		switch v := v.(type) {
-		case list:
-			s = formatListOpt(v, false, rs.allowMulti)
-		case protoreflect.FieldDescriptor, protoreflect.OneofDescriptor, protoreflect.EnumValueDescriptor, protoreflect.MethodDescriptor:
-			s = string(v.(protoreflect.Descriptor).Name())
-		case protoreflect.Descriptor:
-			s = string(v.FullName())
-		case string:
-			s = strconv.Quote(v)
-		case []byte:
-			s = fmt.Sprintf("%q", v)
-		default:
-			s = fmt.Sprint(v)
-		}
-		rs.recs = append(rs.recs, [2]string{a.name, s})
+func (rs *records) Append(v reflect.Value, results ...attrAndName) {
+	for _, r := range results {
+		rs.appendAttribute(v, r.name, r.attr)
 	}
+}
+
+func (rs *records) appendAttribute(val reflect.Value, name string, attrVal any) {
+	if rs.record != nil {
+		rs.record(name)
+	}
+	if attrVal == nil {
+		return
+	}
+	rv := reflect.ValueOf(attrVal)
+	if _, ok := rv.Interface().(protoreflect.Value); ok {
+		rv = rv.MethodByName("Interface").Call(nil)[0]
+		if !rv.IsNil() {
+			rv = rv.Elem()
+		}
+	}
+
+	// Ignore zero values.
+	var isZero bool
+	switch rv.Kind() {
+	case reflect.Interface, reflect.Slice:
+		isZero = rv.IsNil()
+	case reflect.Bool:
+		isZero = rv.Bool() == false
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		isZero = rv.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		isZero = rv.Uint() == 0
+	case reflect.String:
+		isZero = rv.String() == ""
+	}
+	if n, ok := rv.Interface().(list); ok {
+		isZero = n.Len() == 0
+	}
+	if isZero {
+		return
+	}
+
+	// Format the value.
+	var s string
+	v := rv.Interface()
+	switch v := v.(type) {
+	case list:
+		s = formatListOpt(v, false, rs.allowMulti)
+	case protoreflect.FieldDescriptor, protoreflect.OneofDescriptor, protoreflect.EnumValueDescriptor, protoreflect.MethodDescriptor:
+		s = string(v.(protoreflect.Descriptor).Name())
+	case protoreflect.Descriptor:
+		s = string(v.FullName())
+	case string:
+		s = strconv.Quote(v)
+	case []byte:
+		s = fmt.Sprintf("%q", v)
+	default:
+		s = fmt.Sprint(v)
+	}
+	rs.recs = append(rs.recs, [2]string{name, s})
 }
 
 func (rs *records) Join() string {

--- a/vendor/google.golang.org/protobuf/internal/encoding/tag/tag.go
+++ b/vendor/google.golang.org/protobuf/internal/encoding/tag/tag.go
@@ -32,7 +32,7 @@ var byteType = reflect.TypeOf(byte(0))
 func Unmarshal(tag string, goType reflect.Type, evs protoreflect.EnumValueDescriptors) protoreflect.FieldDescriptor {
 	f := new(filedesc.Field)
 	f.L0.ParentFile = filedesc.SurrogateProto2
-	f.L1.EditionFeatures = f.L0.ParentFile.L1.EditionFeatures
+	packed := false
 	for len(tag) > 0 {
 		i := strings.IndexByte(tag, ',')
 		if i < 0 {
@@ -108,7 +108,7 @@ func Unmarshal(tag string, goType reflect.Type, evs protoreflect.EnumValueDescri
 				f.L1.StringName.InitJSON(jsonName)
 			}
 		case s == "packed":
-			f.L1.EditionFeatures.IsPacked = true
+			packed = true
 		case strings.HasPrefix(s, "def="):
 			// The default tag is special in that everything afterwards is the
 			// default regardless of the presence of commas.
@@ -119,6 +119,13 @@ func Unmarshal(tag string, goType reflect.Type, evs protoreflect.EnumValueDescri
 			f.L0.ParentFile = filedesc.SurrogateProto3
 		}
 		tag = strings.TrimPrefix(tag[i:], ",")
+	}
+
+	// Update EditionFeatures after the loop and after we know whether this is
+	// a proto2 or proto3 field.
+	f.L1.EditionFeatures = f.L0.ParentFile.L1.EditionFeatures
+	if packed {
+		f.L1.EditionFeatures.IsPacked = true
 	}
 
 	// The generator uses the group message name instead of the field name.

--- a/vendor/google.golang.org/protobuf/internal/filedesc/desc.go
+++ b/vendor/google.golang.org/protobuf/internal/filedesc/desc.go
@@ -32,6 +32,7 @@ const (
 	EditionProto3      Edition = 999
 	Edition2023        Edition = 1000
 	Edition2024        Edition = 1001
+	EditionUnstable    Edition = 9999
 	EditionUnsupported Edition = 100000
 )
 
@@ -72,9 +73,10 @@ type (
 		EditionFeatures EditionFeatures
 	}
 	FileL2 struct {
-		Options   func() protoreflect.ProtoMessage
-		Imports   FileImports
-		Locations SourceLocations
+		Options       func() protoreflect.ProtoMessage
+		Imports       FileImports
+		OptionImports func() protoreflect.FileImports
+		Locations     SourceLocations
 	}
 
 	// EditionFeatures is a frequently-instantiated struct, so please take care
@@ -126,12 +128,9 @@ func (fd *File) ParentFile() protoreflect.FileDescriptor { return fd }
 func (fd *File) Parent() protoreflect.Descriptor         { return nil }
 func (fd *File) Index() int                              { return 0 }
 func (fd *File) Syntax() protoreflect.Syntax             { return fd.L1.Syntax }
-
-// Not exported and just used to reconstruct the original FileDescriptor proto
-func (fd *File) Edition() int32                  { return int32(fd.L1.Edition) }
-func (fd *File) Name() protoreflect.Name         { return fd.L1.Package.Name() }
-func (fd *File) FullName() protoreflect.FullName { return fd.L1.Package }
-func (fd *File) IsPlaceholder() bool             { return false }
+func (fd *File) Name() protoreflect.Name                 { return fd.L1.Package.Name() }
+func (fd *File) FullName() protoreflect.FullName         { return fd.L1.Package }
+func (fd *File) IsPlaceholder() bool                     { return false }
 func (fd *File) Options() protoreflect.ProtoMessage {
 	if f := fd.lazyInit().Options; f != nil {
 		return f()
@@ -149,6 +148,16 @@ func (fd *File) SourceLocations() protoreflect.SourceLocations { return &fd.lazy
 func (fd *File) Format(s fmt.State, r rune)                    { descfmt.FormatDesc(s, r, fd) }
 func (fd *File) ProtoType(protoreflect.FileDescriptor)         {}
 func (fd *File) ProtoInternal(pragma.DoNotImplement)           {}
+
+// The next two are not part of the FileDescriptor interface. They are just used to reconstruct
+// the original FileDescriptor proto.
+func (fd *File) Edition() int32 { return int32(fd.L1.Edition) }
+func (fd *File) OptionImports() protoreflect.FileImports {
+	if f := fd.lazyInit().OptionImports; f != nil {
+		return f()
+	}
+	return emptyFiles
+}
 
 func (fd *File) lazyInit() *FileL2 {
 	if atomic.LoadUint32(&fd.once) == 0 {
@@ -182,9 +191,9 @@ type (
 		L2 *EnumL2 // protected by fileDesc.once
 	}
 	EnumL1 struct {
-		eagerValues bool // controls whether EnumL2.Values is already populated
-
 		EditionFeatures EditionFeatures
+		Visibility      int32
+		eagerValues     bool // controls whether EnumL2.Values is already populated
 	}
 	EnumL2 struct {
 		Options        func() protoreflect.ProtoMessage
@@ -219,6 +228,11 @@ func (ed *Enum) ReservedNames() protoreflect.Names       { return &ed.lazyInit()
 func (ed *Enum) ReservedRanges() protoreflect.EnumRanges { return &ed.lazyInit().ReservedRanges }
 func (ed *Enum) Format(s fmt.State, r rune)              { descfmt.FormatDesc(s, r, ed) }
 func (ed *Enum) ProtoType(protoreflect.EnumDescriptor)   {}
+
+// This is not part of the EnumDescriptor interface. It is just used to reconstruct
+// the original FileDescriptor proto.
+func (ed *Enum) Visibility() int32 { return ed.L1.Visibility }
+
 func (ed *Enum) lazyInit() *EnumL2 {
 	ed.L0.ParentFile.lazyInit() // implicitly initializes L2
 	return ed.L2
@@ -244,13 +258,13 @@ type (
 		L2 *MessageL2 // protected by fileDesc.once
 	}
 	MessageL1 struct {
-		Enums        Enums
-		Messages     Messages
-		Extensions   Extensions
-		IsMapEntry   bool // promoted from google.protobuf.MessageOptions
-		IsMessageSet bool // promoted from google.protobuf.MessageOptions
-
+		Enums           Enums
+		Messages        Messages
+		Extensions      Extensions
 		EditionFeatures EditionFeatures
+		Visibility      int32
+		IsMapEntry      bool // promoted from google.protobuf.MessageOptions
+		IsMessageSet    bool // promoted from google.protobuf.MessageOptions
 	}
 	MessageL2 struct {
 		Options               func() protoreflect.ProtoMessage
@@ -319,6 +333,11 @@ func (md *Message) Messages() protoreflect.MessageDescriptors     { return &md.L
 func (md *Message) Extensions() protoreflect.ExtensionDescriptors { return &md.L1.Extensions }
 func (md *Message) ProtoType(protoreflect.MessageDescriptor)      {}
 func (md *Message) Format(s fmt.State, r rune)                    { descfmt.FormatDesc(s, r, md) }
+
+// This is not part of the MessageDescriptor interface. It is just used to reconstruct
+// the original FileDescriptor proto.
+func (md *Message) Visibility() int32 { return md.L1.Visibility }
+
 func (md *Message) lazyInit() *MessageL2 {
 	md.L0.ParentFile.lazyInit() // implicitly initializes L2
 	return md.L2

--- a/vendor/google.golang.org/protobuf/internal/filedesc/desc_init.go
+++ b/vendor/google.golang.org/protobuf/internal/filedesc/desc_init.go
@@ -284,6 +284,13 @@ func (ed *Enum) unmarshalSeed(b []byte, sb *strs.Builder, pf *File, pd protorefl
 			case genid.EnumDescriptorProto_Value_field_number:
 				numValues++
 			}
+		case protowire.VarintType:
+			v, m := protowire.ConsumeVarint(b)
+			b = b[m:]
+			switch num {
+			case genid.EnumDescriptorProto_Visibility_field_number:
+				ed.L1.Visibility = int32(v)
+			}
 		default:
 			m := protowire.ConsumeFieldValue(num, typ, b)
 			b = b[m:]
@@ -365,6 +372,13 @@ func (md *Message) unmarshalSeed(b []byte, sb *strs.Builder, pf *File, pd protor
 				md.unmarshalSeedOptions(v)
 			}
 			prevField = num
+		case protowire.VarintType:
+			v, m := protowire.ConsumeVarint(b)
+			b = b[m:]
+			switch num {
+			case genid.DescriptorProto_Visibility_field_number:
+				md.L1.Visibility = int32(v)
+			}
 		default:
 			m := protowire.ConsumeFieldValue(num, typ, b)
 			b = b[m:]

--- a/vendor/google.golang.org/protobuf/internal/filedesc/desc_lazy.go
+++ b/vendor/google.golang.org/protobuf/internal/filedesc/desc_lazy.go
@@ -134,6 +134,7 @@ func (fd *File) unmarshalFull(b []byte) {
 
 	var enumIdx, messageIdx, extensionIdx, serviceIdx int
 	var rawOptions []byte
+	var optionImports []string
 	fd.L2 = new(FileL2)
 	for len(b) > 0 {
 		num, typ, n := protowire.ConsumeTag(b)
@@ -157,6 +158,8 @@ func (fd *File) unmarshalFull(b []byte) {
 					imp = PlaceholderFile(path)
 				}
 				fd.L2.Imports = append(fd.L2.Imports, protoreflect.FileImport{FileDescriptor: imp})
+			case genid.FileDescriptorProto_OptionDependency_field_number:
+				optionImports = append(optionImports, sb.MakeString(v))
 			case genid.FileDescriptorProto_EnumType_field_number:
 				fd.L1.Enums.List[enumIdx].unmarshalFull(v, sb)
 				enumIdx++
@@ -178,6 +181,23 @@ func (fd *File) unmarshalFull(b []byte) {
 		}
 	}
 	fd.L2.Options = fd.builder.optionsUnmarshaler(&descopts.File, rawOptions)
+	if len(optionImports) > 0 {
+		var imps FileImports
+		var once sync.Once
+		fd.L2.OptionImports = func() protoreflect.FileImports {
+			once.Do(func() {
+				imps = make(FileImports, len(optionImports))
+				for i, path := range optionImports {
+					imp, _ := fd.builder.FileRegistry.FindFileByPath(path)
+					if imp == nil {
+						imp = PlaceholderFile(path)
+					}
+					imps[i] = protoreflect.FileImport{FileDescriptor: imp}
+				}
+			})
+			return &imps
+		}
+	}
 }
 
 func (ed *Enum) unmarshalFull(b []byte, sb *strs.Builder) {
@@ -310,7 +330,6 @@ func (md *Message) unmarshalFull(b []byte, sb *strs.Builder) {
 				md.L1.Extensions.List[extensionIdx].unmarshalFull(v, sb)
 				extensionIdx++
 			case genid.DescriptorProto_Options_field_number:
-				md.unmarshalOptions(v)
 				rawOptions = appendOptions(rawOptions, v)
 			}
 		default:
@@ -334,27 +353,6 @@ func (md *Message) unmarshalFull(b []byte, sb *strs.Builder) {
 		}
 	}
 	md.L2.Options = md.L0.ParentFile.builder.optionsUnmarshaler(&descopts.Message, rawOptions)
-}
-
-func (md *Message) unmarshalOptions(b []byte) {
-	for len(b) > 0 {
-		num, typ, n := protowire.ConsumeTag(b)
-		b = b[n:]
-		switch typ {
-		case protowire.VarintType:
-			v, m := protowire.ConsumeVarint(b)
-			b = b[m:]
-			switch num {
-			case genid.MessageOptions_MapEntry_field_number:
-				md.L1.IsMapEntry = protowire.DecodeBool(v)
-			case genid.MessageOptions_MessageSetWireFormat_field_number:
-				md.L1.IsMessageSet = protowire.DecodeBool(v)
-			}
-		default:
-			m := protowire.ConsumeFieldValue(num, typ, b)
-			b = b[m:]
-		}
-	}
 }
 
 func unmarshalMessageReservedRange(b []byte) (r [2]protoreflect.FieldNumber) {

--- a/vendor/google.golang.org/protobuf/internal/filedesc/editions.go
+++ b/vendor/google.golang.org/protobuf/internal/filedesc/editions.go
@@ -13,8 +13,10 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
-var defaultsCache = make(map[Edition]EditionFeatures)
-var defaultsKeys = []Edition{}
+var (
+	defaultsCache = make(map[Edition]EditionFeatures)
+	defaultsKeys  = []Edition{}
+)
 
 func init() {
 	unmarshalEditionDefaults(editiondefaults.Defaults)
@@ -41,7 +43,7 @@ func unmarshalGoFeature(b []byte, parent EditionFeatures) EditionFeatures {
 			b = b[m:]
 			parent.StripEnumPrefix = int(v)
 		default:
-			panic(fmt.Sprintf("unkown field number %d while unmarshalling GoFeatures", num))
+			panic(fmt.Sprintf("unknown field number %d while unmarshalling GoFeatures", num))
 		}
 	}
 	return parent
@@ -76,7 +78,7 @@ func unmarshalFeatureSet(b []byte, parent EditionFeatures) EditionFeatures {
 				// DefaultSymbolVisibility is enforced in protoc, runtimes should not
 				// inspect this value.
 			default:
-				panic(fmt.Sprintf("unkown field number %d while unmarshalling FeatureSet", num))
+				panic(fmt.Sprintf("unknown field number %d while unmarshalling FeatureSet", num))
 			}
 		case protowire.BytesType:
 			v, m := protowire.ConsumeBytes(b)
@@ -150,7 +152,7 @@ func unmarshalEditionDefaults(b []byte) {
 			_, m := protowire.ConsumeVarint(b)
 			b = b[m:]
 		default:
-			panic(fmt.Sprintf("unkown field number %d while unmarshalling EditionDefault", num))
+			panic(fmt.Sprintf("unknown field number %d while unmarshalling EditionDefault", num))
 		}
 	}
 }

--- a/vendor/google.golang.org/protobuf/internal/genid/descriptor_gen.go
+++ b/vendor/google.golang.org/protobuf/internal/genid/descriptor_gen.go
@@ -26,6 +26,7 @@ const (
 	Edition_EDITION_PROTO3_enum_value          = 999
 	Edition_EDITION_2023_enum_value            = 1000
 	Edition_EDITION_2024_enum_value            = 1001
+	Edition_EDITION_UNSTABLE_enum_value        = 9999
 	Edition_EDITION_1_TEST_ONLY_enum_value     = 1
 	Edition_EDITION_2_TEST_ONLY_enum_value     = 2
 	Edition_EDITION_99997_TEST_ONLY_enum_value = 99997

--- a/vendor/google.golang.org/protobuf/internal/impl/codec_map.go
+++ b/vendor/google.golang.org/protobuf/internal/impl/codec_map.go
@@ -113,6 +113,9 @@ func sizeMap(mapv reflect.Value, mapi *mapInfo, f *coderFieldInfo, opts marshalO
 }
 
 func consumeMap(b []byte, mapv reflect.Value, wtyp protowire.Type, mapi *mapInfo, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+	if opts.depth--; opts.depth < 0 {
+		return out, errRecursionDepth
+	}
 	if wtyp != protowire.BytesType {
 		return out, errUnknown
 	}
@@ -170,6 +173,9 @@ func consumeMap(b []byte, mapv reflect.Value, wtyp protowire.Type, mapi *mapInfo
 }
 
 func consumeMapOfMessage(b []byte, mapv reflect.Value, wtyp protowire.Type, mapi *mapInfo, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+	if opts.depth--; opts.depth < 0 {
+		return out, errRecursionDepth
+	}
 	if wtyp != protowire.BytesType {
 		return out, errUnknown
 	}

--- a/vendor/google.golang.org/protobuf/internal/impl/decode.go
+++ b/vendor/google.golang.org/protobuf/internal/impl/decode.go
@@ -102,8 +102,7 @@ var errUnknown = errors.New("unknown")
 
 func (mi *MessageInfo) unmarshalPointer(b []byte, p pointer, groupTag protowire.Number, opts unmarshalOptions) (out unmarshalOutput, err error) {
 	mi.init()
-	opts.depth--
-	if opts.depth < 0 {
+	if opts.depth--; opts.depth < 0 {
 		return out, errRecursionDepth
 	}
 	if flags.ProtoLegacy && mi.isMessageSet {

--- a/vendor/google.golang.org/protobuf/internal/impl/validate.go
+++ b/vendor/google.golang.org/protobuf/internal/impl/validate.go
@@ -68,9 +68,13 @@ func Validate(mt protoreflect.MessageType, in protoiface.UnmarshalInput) (out pr
 	if in.Resolver == nil {
 		in.Resolver = protoregistry.GlobalTypes
 	}
+	if in.Depth == 0 {
+		in.Depth = protowire.DefaultRecursionLimit
+	}
 	o, st := mi.validate(in.Buf, 0, unmarshalOptions{
 		flags:    in.Flags,
 		resolver: in.Resolver,
+		depth:    in.Depth,
 	})
 	if o.initialized {
 		out.Flags |= protoiface.UnmarshalInitialized
@@ -256,6 +260,9 @@ func (mi *MessageInfo) validate(b []byte, groupTag protowire.Number, opts unmars
 	if groupTag > 0 {
 		states[0].typ = validationTypeGroup
 		states[0].endGroup = groupTag
+	}
+	if opts.depth--; opts.depth < 0 {
+		return out, ValidationInvalid
 	}
 	initialized := true
 	start := len(b)
@@ -451,6 +458,13 @@ State:
 						mi:      vi.mi,
 						tail:    b,
 					})
+					if vi.typ == validationTypeMessage ||
+						vi.typ == validationTypeGroup ||
+						vi.typ == validationTypeMap {
+						if opts.depth--; opts.depth < 0 {
+							return out, ValidationInvalid
+						}
+					}
 					b = v
 					continue State
 				case validationTypeRepeatedVarint:
@@ -499,6 +513,9 @@ State:
 						mi:       vi.mi,
 						endGroup: num,
 					})
+					if opts.depth--; opts.depth < 0 {
+						return out, ValidationInvalid
+					}
 					continue State
 				case flags.ProtoLegacy && vi.typ == validationTypeMessageSetItem:
 					typeid, v, n, err := messageset.ConsumeFieldValue(b, false)
@@ -521,6 +538,13 @@ State:
 							mi:   xvi.mi,
 							tail: b[n:],
 						})
+						if xvi.typ == validationTypeMessage ||
+							xvi.typ == validationTypeGroup ||
+							xvi.typ == validationTypeMap {
+							if opts.depth--; opts.depth < 0 {
+								return out, ValidationInvalid
+							}
+						}
 						b = v
 						continue State
 					}
@@ -547,12 +571,14 @@ State:
 		switch st.typ {
 		case validationTypeMessage, validationTypeGroup:
 			numRequiredFields = int(st.mi.numRequiredFields)
+			opts.depth++
 		case validationTypeMap:
 			// If this is a map field with a message value that contains
 			// required fields, require that the value be present.
 			if st.mi != nil && st.mi.numRequiredFields > 0 {
 				numRequiredFields = 1
 			}
+			opts.depth++
 		}
 		// If there are more than 64 required fields, this check will
 		// always fail and we will report that the message is potentially

--- a/vendor/google.golang.org/protobuf/internal/version/version.go
+++ b/vendor/google.golang.org/protobuf/internal/version/version.go
@@ -52,8 +52,8 @@ import (
 const (
 	Major      = 1
 	Minor      = 36
-	Patch      = 8
-	PreRelease = ""
+	Patch      = 11
+	PreRelease = "devel"
 )
 
 // String formats the version string for this module in semver format.

--- a/vendor/google.golang.org/protobuf/proto/decode.go
+++ b/vendor/google.golang.org/protobuf/proto/decode.go
@@ -121,9 +121,8 @@ func (o UnmarshalOptions) unmarshal(b []byte, m protoreflect.Message) (out proto
 
 		out, err = methods.Unmarshal(in)
 	} else {
-		o.RecursionLimit--
-		if o.RecursionLimit < 0 {
-			return out, errors.New("exceeded max recursion depth")
+		if o.RecursionLimit--; o.RecursionLimit < 0 {
+			return out, errRecursionDepth
 		}
 		err = o.unmarshalMessageSlow(b, m)
 	}
@@ -220,6 +219,9 @@ func (o UnmarshalOptions) unmarshalSingular(b []byte, wtyp protowire.Type, m pro
 }
 
 func (o UnmarshalOptions) unmarshalMap(b []byte, wtyp protowire.Type, mapv protoreflect.Map, fd protoreflect.FieldDescriptor) (n int, err error) {
+	if o.RecursionLimit--; o.RecursionLimit < 0 {
+		return 0, errRecursionDepth
+	}
 	if wtyp != protowire.BytesType {
 		return 0, errUnknown
 	}
@@ -305,3 +307,5 @@ func (o UnmarshalOptions) unmarshalMap(b []byte, wtyp protowire.Type, mapv proto
 var errUnknown = errors.New("BUG: internal error (unknown)")
 
 var errDecode = errors.New("cannot parse invalid wire-format data")
+
+var errRecursionDepth = errors.New("exceeded maximum recursion depth")

--- a/vendor/google.golang.org/protobuf/types/descriptorpb/descriptor.pb.go
+++ b/vendor/google.golang.org/protobuf/types/descriptorpb/descriptor.pb.go
@@ -69,6 +69,8 @@ const (
 	// comparison.
 	Edition_EDITION_2023 Edition = 1000
 	Edition_EDITION_2024 Edition = 1001
+	// A placeholder edition for developing and testing unscheduled features.
+	Edition_EDITION_UNSTABLE Edition = 9999
 	// Placeholder editions for testing feature resolution.  These should not be
 	// used or relied on outside of tests.
 	Edition_EDITION_1_TEST_ONLY     Edition = 1
@@ -91,6 +93,7 @@ var (
 		999:        "EDITION_PROTO3",
 		1000:       "EDITION_2023",
 		1001:       "EDITION_2024",
+		9999:       "EDITION_UNSTABLE",
 		1:          "EDITION_1_TEST_ONLY",
 		2:          "EDITION_2_TEST_ONLY",
 		99997:      "EDITION_99997_TEST_ONLY",
@@ -105,6 +108,7 @@ var (
 		"EDITION_PROTO3":          999,
 		"EDITION_2023":            1000,
 		"EDITION_2024":            1001,
+		"EDITION_UNSTABLE":        9999,
 		"EDITION_1_TEST_ONLY":     1,
 		"EDITION_2_TEST_ONLY":     2,
 		"EDITION_99997_TEST_ONLY": 99997,
@@ -4793,11 +4797,11 @@ const file_google_protobuf_descriptor_proto_rawDesc = "" +
 	"\x18EnumValueDescriptorProto\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x16\n" +
 	"\x06number\x18\x02 \x01(\x05R\x06number\x12;\n" +
-	"\aoptions\x18\x03 \x01(\v2!.google.protobuf.EnumValueOptionsR\aoptions\"\xa7\x01\n" +
+	"\aoptions\x18\x03 \x01(\v2!.google.protobuf.EnumValueOptionsR\aoptions\"\xb5\x01\n" +
 	"\x16ServiceDescriptorProto\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12>\n" +
 	"\x06method\x18\x02 \x03(\v2&.google.protobuf.MethodDescriptorProtoR\x06method\x129\n" +
-	"\aoptions\x18\x03 \x01(\v2\x1f.google.protobuf.ServiceOptionsR\aoptions\"\x89\x02\n" +
+	"\aoptions\x18\x03 \x01(\v2\x1f.google.protobuf.ServiceOptionsR\aoptionsJ\x04\b\x04\x10\x05R\x06stream\"\x89\x02\n" +
 	"\x15MethodDescriptorProto\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1d\n" +
 	"\n" +
@@ -5033,14 +5037,15 @@ const file_google_protobuf_descriptor_proto_rawDesc = "" +
 	"\bSemantic\x12\b\n" +
 	"\x04NONE\x10\x00\x12\a\n" +
 	"\x03SET\x10\x01\x12\t\n" +
-	"\x05ALIAS\x10\x02*\xa7\x02\n" +
+	"\x05ALIAS\x10\x02*\xbe\x02\n" +
 	"\aEdition\x12\x13\n" +
 	"\x0fEDITION_UNKNOWN\x10\x00\x12\x13\n" +
 	"\x0eEDITION_LEGACY\x10\x84\a\x12\x13\n" +
 	"\x0eEDITION_PROTO2\x10\xe6\a\x12\x13\n" +
 	"\x0eEDITION_PROTO3\x10\xe7\a\x12\x11\n" +
 	"\fEDITION_2023\x10\xe8\a\x12\x11\n" +
-	"\fEDITION_2024\x10\xe9\a\x12\x17\n" +
+	"\fEDITION_2024\x10\xe9\a\x12\x15\n" +
+	"\x10EDITION_UNSTABLE\x10\x8fN\x12\x17\n" +
 	"\x13EDITION_1_TEST_ONLY\x10\x01\x12\x17\n" +
 	"\x13EDITION_2_TEST_ONLY\x10\x02\x12\x1d\n" +
 	"\x17EDITION_99997_TEST_ONLY\x10\x9d\x8d\x06\x12\x1d\n" +

--- a/vendor/google.golang.org/protobuf/types/known/timestamppb/timestamp.pb.go
+++ b/vendor/google.golang.org/protobuf/types/known/timestamppb/timestamp.pb.go
@@ -172,13 +172,14 @@ import (
 // ) to obtain a formatter capable of generating timestamps in this format.
 type Timestamp struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Represents seconds of UTC time since Unix epoch
-	// 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
-	// 9999-12-31T23:59:59Z inclusive.
+	// Represents seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z. Must
+	// be between -315576000000 and 315576000000 inclusive (which corresponds to
+	// 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z).
 	Seconds int64 `protobuf:"varint,1,opt,name=seconds,proto3" json:"seconds,omitempty"`
-	// Non-negative fractions of a second at nanosecond resolution. Negative
-	// second values with fractions must still have non-negative nanos values
-	// that count forward in time. Must be from 0 to 999,999,999
+	// Non-negative fractions of a second at nanosecond resolution. This field is
+	// the nanosecond portion of the duration, not an alternative to seconds.
+	// Negative second values with fractions must still have non-negative nanos
+	// values that count forward in time. Must be between 0 and 999,999,999
 	// inclusive.
 	Nanos         int32 `protobuf:"varint,2,opt,name=nanos,proto3" json:"nanos,omitempty"`
 	unknownFields protoimpl.UnknownFields

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -360,7 +360,7 @@ golang.org/x/tools/internal/versions
 # gomodules.xyz/jsonpatch/v2 v2.4.0
 ## explicit; go 1.20
 gomodules.xyz/jsonpatch/v2
-# google.golang.org/protobuf v1.36.8
+# google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 ## explicit; go 1.23
 google.golang.org/protobuf/encoding/protodelim
 google.golang.org/protobuf/encoding/prototext


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated the build environment to Go 1.26.
  * Refreshed the Protocol Buffers dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->