### PR TITLE
OCPBUGS-53192: Update code reference to use the default branch name 'main'

### DIFF
--- a/hack/buildconfig.yaml
+++ b/hack/buildconfig.yaml
@@ -33,4 +33,4 @@ parameters:
   value: https://github.com/openshift/cluster-dns-operator
 - description: 'Git branch'
   name: GIT_BRANCH
-  value: master
+  value: main


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the default OpenShift build branch from `master` to `main`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->